### PR TITLE
Add js coverage data for sonarcloud #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ node/
 # js
 node_modules/
 **/dist/**
-**/coverage/**
+**/js_reports/**
 
 # VSCode history plugin
 .history

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ node/
 # js
 node_modules/
 **/dist/**
+**/coverage/**
 
 # VSCode history plugin
 .history

--- a/apps/admin/app/package.json
+++ b/apps/admin/app/package.json
@@ -7,7 +7,7 @@
     "aemsync": "aemsync -w src/main/content/jcr_root",
     "build-production": "NODE_ENV=production webpack --mode=production",
     "test": "jest 2>&1",
-    "test-coverage": "./node_modules/.bin/jest --coverage 2>&1",
+    "test-coverage": "./node_modules/.bin/jest --coverage --coverage-reporters=lcov 2>&1",
     "test-watch": "./node_modules/.bin/jest --watch --colors",
     "watch": "webpack --mode=production --watch --progress"
   },

--- a/apps/admin/app/package.json
+++ b/apps/admin/app/package.json
@@ -40,9 +40,9 @@
   },
   "dependencies": {
     "@adobe/spectrum-css": "2.9.0",
+    "@babel/runtime": "^7.8.7",
     "@react/collection-view": "file:react-collection-view-4.1.5.tgz",
-    "@react/react-spectrum": "file:react-react-spectrum-2.25.0.tgz",
-    "@babel/runtime": "^7.8.7"
+    "@react/react-spectrum": "file:react-react-spectrum-2.25.0.tgz"
   },
   "resolutions": {
     "@react/collection-view": "file:react-collection-view-4.1.5.tgz"
@@ -54,6 +54,7 @@
       "!**/dist/**",
       "!.history/**"
     ],
+    "coverageDirectory": "js_reports/coverage",
     "moduleNameMapper": {
       "\\.(css|less)$": "<rootDir>/.jestconfig/__mocks__/styleMock.js"
     },

--- a/apps/admin/app/pom.xml
+++ b/apps/admin/app/pom.xml
@@ -126,7 +126,7 @@
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>test-coverage</arguments>
+                            <arguments>run test-coverage</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/apps/admin/app/pom.xml
+++ b/apps/admin/app/pom.xml
@@ -121,12 +121,12 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>npm test</id>
+                        <id>npm test and coverage</id>
                         <goals>
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>test</arguments>
+                            <arguments>test-coverage</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -255,6 +255,8 @@
                             <exclude>**/.github/**</exclude>
                             <!-- Ignore babelrc -->
                             <exclude>.babelrc</exclude>
+                            <!-- Ignore js test and coverage reports -->
+                            <exclude>**/js_reports/**</exclude>
                             <!-- Ignore mockito extensions config -->
                             <exclude>**/test/resources/mockito-extensions/*</exclude>
                         </excludes>


### PR DESCRIPTION
May need to modify the sonarcloud general -> languages -> js -> lcov files setting to correctly scrape the data from app/coverage.