### PR TITLE
Introduce ID Tagger (#45)

### DIFF
--- a/apps/admin/app/pom.xml
+++ b/apps/admin/app/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.dx</groupId>
         <artifactId>admin.reactor</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/apps/admin/app/pom.xml
+++ b/apps/admin/app/pom.xml
@@ -62,7 +62,7 @@
                     <embeddeds>
                         <embedded>
                             <groupId>com.adobe.dx</groupId>
-                            <artifactId>admin.core</artifactId>
+                            <artifactId>com.adobe.dx.admin.core</artifactId>
                             <target>/apps/dx/install</target>
                             <filter>true</filter>
                         </embedded>
@@ -141,8 +141,8 @@
     <dependencies>
         <dependency>
             <groupId>com.adobe.dx</groupId>
-            <artifactId>admin.core</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <artifactId>com.adobe.dx.admin.core</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.adobe.dx</groupId>

--- a/apps/admin/core/pom.xml
+++ b/apps/admin/core/pom.xml
@@ -90,9 +90,7 @@
         </dependency>
         <dependency>
             <groupId>com.adobe.dx</groupId>
-            <artifactId>testing</artifactId>
-            <version>0-SNAPSHOT</version>
-            <scope>test</scope>
+            <artifactId>com.adobe.dx.testing</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/apps/admin/core/pom.xml
+++ b/apps/admin/core/pom.xml
@@ -20,10 +20,10 @@
     <parent>
         <groupId>com.adobe.dx</groupId>
         <artifactId>admin.reactor</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
-    <artifactId>admin.core</artifactId>
+    <artifactId>com.adobe.dx.admin.core</artifactId>
     <name>${module.name} - Core bundle</name>
     <description>Core bundle for admin utilities</description>
     <build>

--- a/apps/admin/core/src/main/java/com/adobe/dx/admin/config/fonts/impl/SettingsProviderImpl.java
+++ b/apps/admin/core/src/main/java/com/adobe/dx/admin/config/fonts/impl/SettingsProviderImpl.java
@@ -15,20 +15,13 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.dx.admin.config.fonts.impl;
 
-import java.util.Collections;
-import java.util.Map;
-
 import com.adobe.dx.admin.config.fonts.Settings;
 import com.adobe.dx.admin.config.fonts.SettingsProvider;
 import com.day.cq.wcm.api.Page;
-import com.day.cq.wcm.api.PageEvent;
 import com.day.cq.wcm.api.PageManager;
 
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.caconfig.resource.ConfigurationResourceResolver;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -46,25 +39,17 @@ public class SettingsProviderImpl implements SettingsProvider {
     private static final String SERVICE_USER = "repository-reader-service";
 
     @Reference
-    private ResourceResolverFactory resolverFactory;
-
-    @Reference
     private ConfigurationResourceResolver configResourceResolver;
 
     @Override
     public Settings getSettings(SlingHttpServletRequest request, String configName) {
         String configPath = CLOUDCONFIG_PARENT + configName;
-        Map<String, Object> serviceMap = Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, SERVICE_USER);
-        try (ResourceResolver configResolver = resolverFactory.getServiceResourceResolver(serviceMap)) {
-            LOG.trace("Obtaining ResourceResolver with service user [{}]", SERVICE_USER);
-            PageManager pageManager = request.getResourceResolver().adaptTo(PageManager.class);
-            Page currentPage = pageManager.getContainingPage(request.getResource());
-            Resource environmentResource = getEnvironmentResource(pageManager, currentPage, configPath);
-            if (environmentResource != null) {
-                return environmentResource.adaptTo(Settings.class);
-            }
-        } catch (LoginException e) {
-            LOG.error("Unable to obtain ResourceResolver with service user [{}]", SERVICE_USER);
+        LOG.trace("Obtaining ResourceResolver with service user [{}]", SERVICE_USER);
+        PageManager pageManager = request.getResourceResolver().adaptTo(PageManager.class);
+        Page currentPage = pageManager.getContainingPage(request.getResource());
+        Resource environmentResource = getEnvironmentResource(pageManager, currentPage, configPath);
+        if (environmentResource != null) {
+            return environmentResource.adaptTo(Settings.class);
         }
         return null;
     }

--- a/apps/admin/pom.xml
+++ b/apps/admin/pom.xml
@@ -27,7 +27,7 @@
     </properties>
     <name>${module.name}</name>
     <artifactId>admin.reactor</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>core</module>

--- a/apps/all/pom.xml
+++ b/apps/all/pom.xml
@@ -47,6 +47,10 @@
                 <extensions>true</extensions>
                 <configuration>
                     <requiresRoot>false</requiresRoot>
+                    <filters>
+                        <filter><root>/apps/dx/configs</root></filter>
+                        <filter><root>/apps/dx/install</root></filter>
+                    </filters>
                     <group>com.adobe.dx</group>
                     <name>dx.all</name>
                     <embeddeds>
@@ -64,7 +68,7 @@
                         </embedded>
                         <embedded>
                             <groupId>com.adobe.dx</groupId>
-                            <artifactId>core</artifactId>
+                            <artifactId>com.adobe.dx.core</artifactId>
                             <target>/apps/dx/install</target>
                             <filter>true</filter>
                         </embedded>
@@ -103,19 +107,19 @@
         <dependency>
             <groupId>com.adobe.dx</groupId>
             <artifactId>dx.admin</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.0.1-SNAPSHOT</version>
             <type>zip</type>
         </dependency>
         <dependency>
             <groupId>com.adobe.dx</groupId>
             <artifactId>dx.structure</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.0.1-SNAPSHOT</version>
             <type>zip</type>
         </dependency>
         <dependency>
             <groupId>com.adobe.dx</groupId>
-            <artifactId>core</artifactId>
-            <version>0-SNAPSHOT</version>
+            <artifactId>com.adobe.dx.core</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.adobe.dx</groupId>

--- a/apps/all/src/main/content/jcr_root/apps/dx/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-dx.xml
+++ b/apps/all/src/main/content/jcr_root/apps/dx/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-dx.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-      jcr:primaryType="sling:OsgiConfig"
-      service.ranking="0"
-      user.mapping="[com.adobe.dx.admin.config=repository-reader-service]"/>

--- a/apps/all/src/main/content/jcr_root/apps/dx/configs/config.author/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-dx_admin.config
+++ b/apps/all/src/main/content/jcr_root/apps/dx/configs/config.author/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-dx_admin.config
@@ -1,0 +1,1 @@
+user.mapping=["com.adobe.dx.admin.core\=repository-reader-service"]

--- a/apps/all/src/main/content/jcr_root/apps/dx/configs/config/com.adobe.dx.domtagging.internal.IDTagger.config
+++ b/apps/all/src/main/content/jcr_root/apps/dx/configs/config/com.adobe.dx.domtagging.internal.IDTagger.config
@@ -1,0 +1,1 @@
+acceptedTypes=["dx/components/structure/.*","core/wcm/components/.*"]

--- a/apps/all/src/main/content/jcr_root/apps/dx/configs/config/com.adobe.dx.responsive.internal.ResponsiveServiceImpl.config
+++ b/apps/all/src/main/content/jcr_root/apps/dx/configs/config/com.adobe.dx.responsive.internal.ResponsiveServiceImpl.config
@@ -1,0 +1,1 @@
+breakpoints=["Mobile", "Tablet", "Desktop"]

--- a/apps/all/src/main/content/jcr_root/apps/dx/configs/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-dx_core.config
+++ b/apps/all/src/main/content/jcr_root/apps/dx/configs/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-dx_core.config
@@ -1,0 +1,4 @@
+user.mapping=[\
+  "com.adobe.dx.core\=repository-reader-service",\
+  "com.adobe.dx.core:content-writer\=content-writer-service"\
+]

--- a/apps/all/src/main/content/jcr_root/apps/dx/install/.content.xml
+++ b/apps/all/src/main/content/jcr_root/apps/dx/install/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="nt:folder"/>

--- a/apps/structure/app/pom.xml
+++ b/apps/structure/app/pom.xml
@@ -60,7 +60,7 @@
                     <embeddeds>
                         <embedded>
                             <groupId>com.adobe.dx</groupId>
-                            <artifactId>structure.core</artifactId>
+                            <artifactId>com.adobe.dx.structure.core</artifactId>
                             <target>/apps/dx/install</target>
                         </embedded>
                     </embeddeds>
@@ -130,8 +130,8 @@
     <dependencies>
         <dependency>
             <groupId>com.adobe.dx</groupId>
-            <artifactId>structure.core</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <artifactId>com.adobe.dx.structure.core</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.adobe.dx</groupId>

--- a/apps/structure/app/pom.xml
+++ b/apps/structure/app/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.dx</groupId>
         <artifactId>structure.reactor</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/apps/structure/app/src/main/content/jcr_root/apps/dx/components/structure/flex/.content.xml
+++ b/apps/structure/app/src/main/content/jcr_root/apps/dx/components/structure/flex/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="cq:Component"
+          cq:isContainer="{Boolean}true"
+          componentGroup="DX"
+          jcr:title="Flex"/>

--- a/apps/structure/core/pom.xml
+++ b/apps/structure/core/pom.xml
@@ -90,9 +90,7 @@
         </dependency>
         <dependency>
             <groupId>com.adobe.dx</groupId>
-            <artifactId>testing</artifactId>
-            <version>0-SNAPSHOT</version>
-            <scope>test</scope>
+            <artifactId>com.adobe.dx.testing</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/apps/structure/core/pom.xml
+++ b/apps/structure/core/pom.xml
@@ -20,10 +20,10 @@
     <parent>
         <groupId>com.adobe.dx</groupId>
         <artifactId>structure.reactor</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
-    <artifactId>structure.core</artifactId>
+    <artifactId>com.adobe.dx.structure.core</artifactId>
     <name>${module.name} - Core bundle</name>
     <description>Core bundle for structure components</description>
     <build>

--- a/apps/structure/pom.xml
+++ b/apps/structure/pom.xml
@@ -27,7 +27,7 @@
     </properties>
     <name>${module.name}</name>
     <artifactId>structure.reactor</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>core</module>

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -23,8 +23,9 @@
         <version>0-SNAPSHOT</version>
         <relativePath>../../parent</relativePath>
     </parent>
-    <artifactId>core</artifactId>
+    <artifactId>com.adobe.dx.core</artifactId>
     <name>${project.prefix} - Core</name>
+    <version>0.0.1-SNAPSHOT</version>
     <description>Core classes for dx projects</description>
     <build>
         <plugins>
@@ -44,6 +45,10 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-baseline-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>sling-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -103,9 +103,7 @@
         </dependency>
         <dependency>
             <groupId>com.adobe.dx</groupId>
-            <artifactId>testing</artifactId>
-            <version>0-SNAPSHOT</version>
-            <scope>test</scope>
+            <artifactId>com.adobe.dx.testing</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/bundles/core/src/main/java/com/adobe/dx/bindings/internal/DxBindingsValueProvider.java
+++ b/bundles/core/src/main/java/com/adobe/dx/bindings/internal/DxBindingsValueProvider.java
@@ -31,6 +31,7 @@ import org.apache.sling.scripting.api.BindingsValuesProvider;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 
 @Component(service = BindingsValuesProvider.class,
@@ -38,7 +39,8 @@ import org.osgi.service.component.annotations.Reference;
         Constants.SERVICE_RANKING + ":Integer=1500",
         "javax.script.name=sightly",
         "javax.script.name=sling-models"
-    }
+    },
+    configurationPolicy = ConfigurationPolicy.REQUIRE
 )
 /**
  * provides DX bindings

--- a/bundles/core/src/main/java/com/adobe/dx/domtagging/internal/IDTagger.java
+++ b/bundles/core/src/main/java/com/adobe/dx/domtagging/internal/IDTagger.java
@@ -1,0 +1,216 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.dx.domtagging.internal;
+
+import static org.apache.sling.api.resource.ResourceResolverFactory.SUBSERVICE;
+
+import com.day.cq.replication.Preprocessor;
+import com.day.cq.replication.ReplicationAction;
+import com.day.cq.replication.ReplicationActionType;
+import com.day.cq.replication.ReplicationException;
+import com.day.cq.replication.ReplicationOptions;
+import com.day.cq.wcm.api.Page;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.sling.api.resource.AbstractResourceVisitor;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.resource.ValueMap;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * will tag every untagged component with an id that is meant to be unique and to stick to it
+ */
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE)
+@Designate(ocd = IDTagger.Configuration.class)
+public class IDTagger implements Preprocessor {
+    private final Logger LOG = LoggerFactory.getLogger(IDTagger.class);
+    static final String PN_PAGEHASH = "dx_pageId";
+    static final String PN_COMPID = "dx_id";
+
+    final short ID_SIZE = 8;
+
+    static final String SERVICE_NAME = "content-writer";
+
+    List<Pattern> acceptedTypes;
+
+    @Reference
+    ResourceResolverFactory resourceResolverFactory;
+
+    @Activate
+    @Modified
+    public void activate(Configuration configuration) {
+        acceptedTypes = new ArrayList<>();
+        for (String regexp : configuration.acceptedTypes()) {
+            acceptedTypes.add(Pattern.compile(regexp));
+        }
+    }
+
+    @Override
+    public void preprocess(ReplicationAction replicationAction, ReplicationOptions replicationOptions) throws ReplicationException {
+        if (ReplicationActionType.ACTIVATE.equals(replicationAction.getType())) {
+            try (ResourceResolver resourceResolver =
+                     resourceResolverFactory.getServiceResourceResolver(Collections.singletonMap(SUBSERVICE, SERVICE_NAME))) {
+                Resource currentResource = resourceResolver.getResource(replicationAction.getPath());
+                Page currentPage = currentResource.adaptTo(Page.class);
+                if (currentPage != null) {
+                    //we just tag page resources
+                    tagPage(currentPage);
+                }
+                resourceResolver.commit();
+            } catch (LoginException | PersistenceException e) {
+                LOG.error("Issues with current user or content, will not tag that resource", e);
+            }
+        }
+        String path = replicationAction.getPath();
+    }
+
+    void tagPage(Page currentPage) {
+        String pageHash = getUniqueId(currentPage.getPath(), false);
+        for (Iterator<Resource> componentIterator = new ComponentIterator(acceptedTypes, currentPage.getContentResource());
+             componentIterator.hasNext();) {
+            Resource component = componentIterator.next();
+            if (!isResourceTagValid(pageHash, component)) {
+                tagResource(pageHash, component);
+            }
+        }
+    }
+
+    /**
+     * Assuming this resource is "taggable", this method will tell us it is validly tagged
+     * that is it has a tag, and current page id tag (not time salted) is still ok.
+     *
+     * @param currentPageHash  hash from page whom we are browsing the content from
+     * @param resource resource we want to check
+     * @return
+     */
+    boolean isResourceTagValid(@NotNull String currentPageHash, @NotNull Resource resource) {
+        ValueMap map = resource.getValueMap();
+        if (map.containsKey(PN_PAGEHASH) && map.containsKey(PN_COMPID)) {
+            return currentPageHash.equals(map.get(PN_PAGEHASH, String.class));
+        }
+        return false;
+    }
+
+    /**
+     * Tags a given resource with both current page id, and component id
+     *
+     * @param currentPageHash hash from page whom we are browsing the content from
+     * @param resource resource we want to tag
+     */
+    void tagResource(String currentPageHash, Resource resource) {
+        ModifiableValueMap map = resource.adaptTo(ModifiableValueMap.class);
+        if (map != null) {
+            map.put(PN_PAGEHASH, currentPageHash);
+            map.put(PN_COMPID, getUniqueId(resource.getPath(), true));
+        }
+    }
+
+    /**
+     * Creates a Unique ID based on a path.
+     *
+     * @param path          The path we should generate an ID from
+     * @param timeSalt      wether we should salt it with a time based salt or not
+     * @return              The unique ID (first <code>ID_SIZE</code> chars of sha1 hash)
+     */
+    String getUniqueId(final String path, boolean timeSalt) {
+        String source = path;
+        if (timeSalt) {
+            source += Calendar.getInstance().toString();
+        }
+        String sha1 = DigestUtils.sha1Hex(source);
+        return sha1.substring(0, ID_SIZE);
+    }
+
+    /**
+     * lists all resource in a resource tree that have resource type corresponding to passed patterns
+     */
+    static class ComponentIterator extends AbstractResourceVisitor implements Iterator<Resource> {
+
+        Collection<Pattern> acceptedTypes;
+        List<Resource> internalList = new ArrayList<>();
+        Iterator<Resource> internalIT;
+
+        public ComponentIterator(Collection<Pattern> acceptedTypes, Resource root) {
+            this.acceptedTypes = acceptedTypes;
+            accept(root);
+        }
+
+        @Override
+        protected void visit(@NotNull Resource resource) {
+            if (StringUtils.isNotBlank(resource.getResourceType())) {
+                for (Pattern pattern: acceptedTypes) {
+                    if (pattern.matcher(resource.getResourceType()).matches()) {
+                        internalList.add(resource);
+                        break;
+                    }
+                }
+            }
+        }
+
+        Iterator<Resource> getIterator() {
+            if (internalIT == null) {
+                internalIT = internalList.iterator();
+            }
+            return internalIT;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return getIterator().hasNext();
+        }
+
+        @Override
+        public Resource next() {
+            return getIterator().next();
+        }
+    }
+
+    @ObjectClassDefinition(name = "Adobe DX ID Tagger")
+    public @interface Configuration {
+
+        @AttributeDefinition(
+            name = "Accepted types",
+            description = "list of pattern (https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html) "
+                + "for resource types that should be tagged with an id"
+        )
+        @SuppressWarnings("squid:S00100")
+        String[] acceptedTypes() default { "dx/components/structure/.*" };
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/dx/responsive/internal/ResponsiveServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/dx/responsive/internal/ResponsiveServiceImpl.java
@@ -25,13 +25,8 @@ import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
-@Component(
-    immediate = true,
-    configurationPolicy = ConfigurationPolicy.REQUIRE
-)
-@Designate(
-    ocd= ResponsiveServiceImpl.Configuration.class
-)
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE)
+@Designate(ocd= ResponsiveServiceImpl.Configuration.class)
 public class ResponsiveServiceImpl implements ResponsiveService {
 
     Configuration configuration;
@@ -50,15 +45,9 @@ public class ResponsiveServiceImpl implements ResponsiveService {
     @ObjectClassDefinition(name = "Adobe DX Responsive Settings")
     public @interface Configuration {
 
-        /**
-         * Site Locale Key.
-         *
-         * @return unique key that identifies this config.
-         */
         @AttributeDefinition(
-            name = "Site Locale Key",
-            description = "A unique key that identifies this config. The key is also used as a "
-                + "placeholder key."
+            name = "Breakpoints",
+            description = "ordered list of breakpoints"
         )
         @SuppressWarnings("squid:S00100")
         String[] breakpoints() default {"Mobile", "Tablet", "Desktop"};

--- a/bundles/core/src/test/java/com/adobe/dx/domtagging/internal/IDTaggerTest.java
+++ b/bundles/core/src/test/java/com/adobe/dx/domtagging/internal/IDTaggerTest.java
@@ -1,0 +1,140 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.dx.domtagging.internal;
+
+import static com.adobe.dx.domtagging.internal.IDTagger.PN_COMPID;
+import static com.adobe.dx.domtagging.internal.IDTagger.PN_PAGEHASH;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.adobe.dx.testing.AbstractTest;
+import com.day.cq.replication.ReplicationAction;
+import com.day.cq.replication.ReplicationActionType;
+import com.day.cq.replication.ReplicationException;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.resource.ValueMap;
+import org.junit.jupiter.api.Test;
+
+class IDTaggerTest extends AbstractTest {
+
+    private static final String REL_ROOT = "/jcr:content/root";
+
+    List<String> expected = Arrays.asList(
+        CONTENT_ROOT + REL_ROOT,
+        CONTENT_ROOT + REL_ROOT + "/children/image",
+        CONTENT_ROOT + REL_ROOT + "/children/unwantedContainer/image");
+
+    @Test
+    public void testComponentIterator() {
+        context.load().json("/mocks/domtagging.internal/page-tree.json", CONTENT_ROOT);
+        Pattern dx = Pattern.compile("some/dx/.*");
+        Pattern other = Pattern.compile("some/other/.*");
+        IDTagger.ComponentIterator iterator = new IDTagger.ComponentIterator(Arrays.asList(dx, other),
+            context.resourceResolver().getResource(CONTENT_ROOT + "/jcr:content"));
+        List<String> result = (List<String>) IteratorUtils.toList(iterator).stream()
+            .map(r -> ((Resource)r).getPath())
+            .collect(Collectors.toList());
+        assertEquals(expected, result, "Configured resource types (and only them) should have been grabbed");
+    }
+
+    @Test
+    public void testFirstTagging() throws Exception {
+        firstTag();
+        for (String path : expected) {
+            ValueMap comp  = getVM(path);
+            assertNotNull(comp.get(PN_PAGEHASH, String.class), "there should be a page hash for " + path);
+            assertNotNull(comp.get(PN_COMPID, String.class), "there should be a component hash for " + path);
+        }
+    }
+
+    @Test
+    public void testMovedTagging() throws Exception {
+        IDTagger tagger = firstTag();
+        Map<String, String> oldHashes = new HashMap<>();
+        //collecting old hashes
+        for (String path : expected) {
+            ValueMap comp = getVM(path);
+            String hash = comp.get(PN_COMPID, String.class);
+            assertNotNull(hash);
+            oldHashes.put(path, hash);
+        }
+        //adding a component with bad hashes
+        String copiedComponent = CONTENT_ROOT + "/jcr:content/root/moved";
+        String oldPageHash = "somehash";
+        String oldHash = "blahblah";
+        context.build().resource(copiedComponent,
+            "sling:resourceType", "some/dx/comp",
+            PN_COMPID, oldHash,
+            PN_PAGEHASH, oldPageHash).commit();
+        for (String path : expected) {
+            ValueMap comp = getVM(path);
+            assertEquals(oldHashes.get(path), comp.get(PN_COMPID, String.class),"old hashes should still be untouched");
+        }
+        tagger.preprocess(mockContentRootActivation(), null);
+        ValueMap comp = getVM(copiedComponent);
+        String pageHash = comp.get(PN_PAGEHASH, String.class);
+        String newHash = comp.get(PN_COMPID, String.class);
+        assertFalse(oldPageHash.equals(pageHash), "page hash should have been updated");
+        assertFalse(oldHash.equals(newHash), "comp hash should have been updated");
+    }
+
+    @Test
+    public void testNonPage() throws Exception {
+        context.build().resource(CONTENT_ROOT, "blah", "blah").commit();
+        IDTagger tagger = mockTagger();
+        Map oldMap = getVM(CONTENT_ROOT);
+        tagger.preprocess(mockContentRootActivation(), null);
+        Map newMap = getVM(CONTENT_ROOT);
+        assertEquals(oldMap, newMap, "should be left untouched");
+    }
+
+    IDTagger mockTagger() throws ReplicationException, LoginException {
+        IDTagger tagger = new IDTagger();
+        ResourceResolverFactory factory = mock(ResourceResolverFactory.class);
+        when(factory.getServiceResourceResolver(any())).thenReturn(context.resourceResolver());
+        tagger.resourceResolverFactory = factory;
+        context.registerInjectActivateService(tagger, "acceptedTypes",
+            new String[] {"some/dx/.*","some/other/.*"});
+        return tagger;
+    }
+
+    IDTagger firstTag() throws ReplicationException, LoginException {
+        context.load().json("/mocks/domtagging.internal/page-tree.json", CONTENT_ROOT);
+        IDTagger tagger = mockTagger();
+        tagger.preprocess(mockContentRootActivation() , null);
+        return tagger;
+    }
+
+    ReplicationAction mockContentRootActivation() {
+        ReplicationAction action = mock(ReplicationAction.class);
+        when(action.getType()).thenReturn(ReplicationActionType.ACTIVATE);
+        when(action.getPath()).thenReturn(CONTENT_ROOT);
+        return action;
+    }
+}

--- a/bundles/core/src/test/resources/mocks/domtagging.internal/page-tree.json
+++ b/bundles/core/src/test/resources/mocks/domtagging.internal/page-tree.json
@@ -1,0 +1,29 @@
+{
+  "jcr:primaryType": "cq:Page",
+  "jcr:content": {
+    "jcr:primaryType": "cq:PageContent",
+    "jcr:title": "Some page",
+    "sling:resourceType": "some/page",
+    "cq:template": "/some/cloud/config",
+    "root" : {
+      "sling:resourceType": "some/dx/container",
+      "children": {
+        "image": {
+          "sling:resourceType": "some/dx/image"
+        },
+        "unwanted": {
+          "sling:resourceType": "some/foo/bar"
+        },
+        "unwantedContainer": {
+          "sling:resourceType": "some/foo/bar/container",
+          "image": {
+            "sling:resourceType": "some/other/image"
+          },
+          "unwanted": {
+            "sling:resourceType": "some/foo/bar"
+          }
+        }
+      }
+    }
+  }
+}

--- a/bundles/testing/pom.xml
+++ b/bundles/testing/pom.xml
@@ -25,6 +25,7 @@
     </parent>
     <artifactId>com.adobe.dx.testing</artifactId>
     <name>${project.prefix} - Testing</name>
+    <version>0.0.1-SNAPSHOT</version>
     <description>Testing utilities for dx project</description>
     <build>
         <plugins>

--- a/bundles/testing/pom.xml
+++ b/bundles/testing/pom.xml
@@ -23,7 +23,7 @@
         <version>0-SNAPSHOT</version>
         <relativePath>../../parent</relativePath>
     </parent>
-    <artifactId>testing</artifactId>
+    <artifactId>com.adobe.dx.testing</artifactId>
     <name>${project.prefix} - Testing</name>
     <description>Testing utilities for dx project</description>
     <build>

--- a/bundles/testing/src/main/java/com/adobe/dx/testing/AbstractTest.java
+++ b/bundles/testing/src/main/java/com/adobe/dx/testing/AbstractTest.java
@@ -15,6 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.dx.testing;
 
+import org.apache.sling.api.resource.ValueMap;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.apache.sling.testing.mock.caconfig.ContextPlugins.CACONFIG;
@@ -33,4 +34,7 @@ public class AbstractTest {
         .plugin(CACONFIG)
         .build();
 
+    protected ValueMap getVM(String path) {
+        return context.resourceResolver().getResource(path).getValueMap();
+    }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -716,6 +716,12 @@ ${bundle.additional.properties}
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>com.adobe.dx</groupId>
+                <artifactId>com.adobe.dx.testing</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -25,6 +25,7 @@
         <aem.publish.host>localhost</aem.publish.host>
         <aem.publish.port>4503</aem.publish.port>
         <aem.contextPath />
+        <sling.url>http://${aem.host}:${aem.port}${aem.contextPath}</sling.url>
         <aem.java.version>8</aem.java.version>
         <bnd.version>4.2.0</bnd.version>
         <bundle.additional.properties></bundle.additional.properties>
@@ -226,6 +227,8 @@
                             <exclude>**/.vltignore</exclude>
                             <!-- Ignore .vlt files -->
                             <exclude>**/.vlt</exclude>
+                            <!-- Ignore .config files -->
+                            <exclude>**/*.config</exclude>
                             <!-- Ignore .svg files -->
                             <exclude>**/*.svg</exclude>
                             <!-- Exclude all JSON files -->
@@ -276,6 +279,16 @@
                     <version>1.2.0-1.4.0</version>
                     <configuration>
                         <failOnWarnings>true</failOnWarnings>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.sling</groupId>
+                    <artifactId>sling-maven-plugin</artifactId>
+                    <version>2.4.0</version>
+                    <configuration>
+                        <slingUrl>${sling.url}/system/console</slingUrl>
+                        <user>${sling.user}</user>
+                        <password>${sling.password}</password>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -427,7 +440,7 @@ ${bundle.additional.properties}
                     <artifactId>content-package-maven-plugin</artifactId>
                     <version>1.0.2</version>
                     <configuration>
-                        <targetURL>http://${aem.host}:${aem.port}${aem.contextPath}/crx/packmgr/service.jsp</targetURL>
+                        <targetURL>${sling.url}/crx/packmgr/service.jsp</targetURL>
                         <failOnError>true</failOnError>
                         <verbose>true</verbose>
                         <userId>${vault.user}</userId>


### PR DESCRIPTION
- adds 8 chars digits hashes dx_id and dx_pageId properties to each (configured) component, available for their script for consumption, at replication time of the containing page,
- page id is computed each time a page is replicated, if it has changed, dx_id will be re-computed: this allows to work around the MSM issue: where we want the ID to be recomputed, also if the component is copied from another page it will be recomputed. This is the only condition for it to be recomputed: if the component is moved around the page, id will stay the same, which should allow 3rd parties to find it back
- did some fix around POM and service user mapping,
- also add configs to all for now, make all services requiring a configuration (making it easy not to take them in)

<img width="385" alt="Screenshot 2020-03-23 at 15 59 45" src="https://user-images.githubusercontent.com/1032754/77330243-583c9300-6d1f-11ea-9b5a-b66821410f5c.png">
