### PR TITLE
GH-5 enable releases for adobe-dx

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,0 +1,45 @@
+# Releasing
+
+## Prerequesites
+- to do a release, you must know what module, with what [version](https://semver.org/) you should use.
+- to prepare or perform a adobe-dx release, you must have write access to that repository, and a [token that has write access to it](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-apache-maven-for-use-with-github-packages#authenticating-to-github-packages)
+- each and every release must be signed, so you need to have GPG key (https://help.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key)
+- once done, you can add in your `~/.m2/settings.xml` following profile
+```
+...
+<profiles>
+    <profile>
+        <id>dx-release</id>
+        <properties>
+            <gpg.keyname><!--your public key--></gpg.keyname>
+            <gpg.passphrase><!--encrypted gpg passphrase--></gpg.passphrase>
+        </properties>
+    </profile>
+</profiles>
+```
+- note that depending on your OS, you may hit https://issues.apache.org/jira/browse/MGPG-59 which is plugin's gpg agent trying 
+to access IO. Message being something like 
+
+```gpg: signing failed: Inappropriate ioctl for device```
+
+As proposed in the ticket, in order to counter balance this, pls execute following command _before_ preparing release:
+
+```gpg -u <your key's email> --use-agent --armor --detach-sign --output $(mktemp) pom.xml```
+
+## Release
+
+### commands
+
+1. check that your local is up to date with origin,
+2. check that a release would work by running a dry run release
+```mvn release:prepare -Pdx-release -DdryRun=true```
+if things looks good to you, you can rollback all changes
+```mvn release:rollback -Pdx-release -DdryRun=true```
+3. prepare the release 
+```mvn release:prepare -Pdx-release```
+4. perform the release
+```mvn release:perform -Pdx-release```
+5. (if anything goes wrong) rollback the release
+```mvn release:rollback -Pdx-release``` 
+6. (if things went well) go to https://github.com/adobe/adobe-dx/packages 
+and check there released artifacts. Eventually do an announce / gh release if important one.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,6 +24,8 @@ jobs:
           java-version: '11'
           java-package: jdk
       - name: maven clean install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo start simple maven build
           mvn -B --no-transfer-progress -s settings.xml

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A toolkit for AEM to help build exceptional digital experiences, on top of [AEM 
 
 #### building DX modules
 
+first ensure you have both `github-dx` maven repository setup ([server and repository as in this settings.xml file](./settings.xml))
+
 DX is a set of modules that can be used separately, you can build them all using
  
 ```mvn```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ if you want your build to be directly installed to your local aem instance, just
 
 Contributions are welcomed! Read the [Contributing Guide](./.github/CONTRIBUTING.md) for more information.
 
+### Releasing
+
+For authorized people willing to release a module, look at [Release guide](./.github/RELEASING.md) for more information.
+
 ### Discussion
 
 For ongoing discussions related to adobe-dx, see [the adobe-dx-dev page](https://github.com/orgs/adobe/teams/adobe-dx-devs).

--- a/apps/admin/pom.xml
+++ b/apps/admin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.adobe.dx</groupId>
         <artifactId>parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>6</version>
         <relativePath>../../parent/main</relativePath>
     </parent>
     <properties>

--- a/apps/all/pom.xml
+++ b/apps/all/pom.xml
@@ -25,7 +25,7 @@
         <groupId>com.adobe.dx</groupId>
         <artifactId>parent</artifactId>
         <version>6</version>
-        <relativePath>../../parent/main/pom.xml</relativePath>
+        <relativePath>../../parent/main</relativePath>
     </parent>
 
     <!-- ====================================================================== -->

--- a/apps/all/pom.xml
+++ b/apps/all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.adobe.dx</groupId>
         <artifactId>parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>6</version>
         <relativePath>../../parent/main/pom.xml</relativePath>
     </parent>
 
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>com.adobe.dx</groupId>
             <artifactId>repository-structure</artifactId>
-            <version>0-SNAPSHOT</version>
+            <version>6</version>
             <type>zip</type>
         </dependency>
         <dependency>

--- a/apps/docs/pom.xml
+++ b/apps/docs/pom.xml
@@ -24,7 +24,7 @@
         <groupId>com.adobe.dx</groupId>
         <artifactId>parent</artifactId>
         <version>6</version>
-        <relativePath>../../parent/main/pom.xml</relativePath>
+        <relativePath>../../parent/main</relativePath>
     </parent>
 
     <!-- ====================================================================== -->

--- a/apps/docs/pom.xml
+++ b/apps/docs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.dx</groupId>
         <artifactId>parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>6</version>
         <relativePath>../../parent/main/pom.xml</relativePath>
     </parent>
 
@@ -33,6 +33,7 @@
     <artifactId>dx.docs</artifactId>
     <packaging>content-package</packaging>
     <name>${project.prefix} - Documentation package</name>
+    <version>0.0.1-SNAPSHOT</version>
 
     <!-- ====================================================================== -->
     <!-- B U I L D   D E F I N I T I O N                                        -->

--- a/apps/structure/pom.xml
+++ b/apps/structure/pom.xml
@@ -20,7 +20,7 @@
         <groupId>com.adobe.dx</groupId>
         <artifactId>parent</artifactId>
         <version>6</version>
-        <relativePath>../../parent/main/pom.xml</relativePath>
+        <relativePath>../../parent/main</relativePath>
     </parent>
     <properties>
         <module.name>${project.prefix} - Structure Components</module.name>

--- a/apps/structure/pom.xml
+++ b/apps/structure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.adobe.dx</groupId>
         <artifactId>parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>6</version>
         <relativePath>../../parent/main/pom.xml</relativePath>
     </parent>
     <properties>

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.adobe.dx</groupId>
         <artifactId>parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>6</version>
         <relativePath>../../parent/main</relativePath>
     </parent>
     <artifactId>com.adobe.dx.core</artifactId>

--- a/bundles/testing/pom.xml
+++ b/bundles/testing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.adobe.dx</groupId>
         <artifactId>parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>6</version>
         <relativePath>../../parent/main</relativePath>
     </parent>
     <artifactId>com.adobe.dx.testing</artifactId>

--- a/parent/repository-structure/pom.xml
+++ b/parent/repository-structure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.adobe.dx</groupId>
         <artifactId>parent</artifactId>
-        <version>7-SNAPSHOT</version>
+        <version>6</version>
         <relativePath>../main</relativePath>
     </parent>
 
@@ -28,6 +28,7 @@
     <!-- ====================================================================== -->
     <artifactId>repository-structure</artifactId>
     <name>Adobe DX - Repository Structure Package</name>
+    <version>7-SNAPSHOT</version>
     <packaging>content-package</packaging>
     <description>
         Empty package that defines the structure of the Adobe Experience Manager repository the Code packages in this project deploy into.

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>com.adobe.dx</groupId>
         <artifactId>parent</artifactId>
-        <version>0-SNAPSHOT</version>
+        <version>6</version>
         <relativePath>parent/main/pom.xml</relativePath>
     </parent>
     <artifactId>reactor</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,9 @@
         <groupId>com.adobe.dx</groupId>
         <artifactId>parent</artifactId>
         <version>6</version>
-        <relativePath>parent/main/pom.xml</relativePath>
+        <relativePath>parent/main</relativePath>
     </parent>
+
     <artifactId>reactor</artifactId>
     <packaging>pom</packaging>
 

--- a/settings.xml
+++ b/settings.xml
@@ -24,6 +24,18 @@
 
             <repositories>
                 <repository>
+                    <id>github-dx</id>
+                    <name>GitHub Adobe DX Apache Maven Packages</name>
+                    <url>https://maven.pkg.github.com/adobe/adobe-dx</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
                     <id>adobe-public-releases</id>
                     <name>Adobe Public Repository</name>
                     <url>https://repo.adobe.com/nexus/content/groups/public</url>

--- a/settings.xml
+++ b/settings.xml
@@ -11,6 +11,13 @@
 	governing permissions and limitations under the License.
 -->
 <settings>
+    <servers>
+        <server>
+            <id>github-dx</id>
+            <username>releng</username>
+            <password>${env.GITHUB_TOKEN}</password>
+        </server>
+    </servers>
     <profiles>
         <!-- ====================================================== -->
         <!-- A D O B E   P U B L I C   P R O F I L E                -->


### PR DESCRIPTION
- release maven configuration is already up there,
- pointing to fixed released version of parent, with additional repository in settings
- add release instructions