### PR TITLE
Export structure as sling model

### DIFF
--- a/apps/structure/core/pom.xml
+++ b/apps/structure/core/pom.xml
@@ -43,6 +43,33 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+Bundle-Category: dx
+Bundle-SymbolicName: com.adobe.dx.structure
+Import-Package: javax.annotation;version=0.0.0,*
+-exportcontents: ${packages;VERSIONED}
+Sling-Model-Packages: com.adobe.dx.structure
+-snapshot: ${tstamp;yyyyMMddHHmmssSSS}
+Bundle-DocURL:
+-plugin org.apache.sling.caconfig.bndplugin.ConfigurationClassScannerPlugin
+                                ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.sling</groupId>
+                        <artifactId>org.apache.sling.caconfig.bnd-plugin</artifactId>
+                        <version>1.0.2</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
@@ -72,6 +99,10 @@
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>
@@ -94,7 +125,7 @@
         <dependency>
             <groupId>com.adobe.dx</groupId>
             <artifactId>com.adobe.dx.testing</artifactId>
-            <version>0.0.2</version>
+            <version>0.0.3-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Description

The BackgroundGradient Model was not being registered, so would not work correctly on import.

This should have been added when the structure app was created.

## Related Issue

#104 

