### PR TITLE
The reactor POMs have to be deployed

### DIFF
--- a/apps/admin/pom.xml
+++ b/apps/admin/pom.xml
@@ -24,7 +24,6 @@
     </parent>
     <properties>
         <module.name>${project.prefix} - Admin</module.name>
-        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <scm>

--- a/apps/content/pom.xml
+++ b/apps/content/pom.xml
@@ -27,7 +27,6 @@
     </parent>
     <properties>
         <module.name>${project.prefix} - Content Components</module.name>
-        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <modelVersion>4.0.0</modelVersion>

--- a/apps/structure/pom.xml
+++ b/apps/structure/pom.xml
@@ -24,7 +24,6 @@
     </parent>
     <properties>
         <module.name>${project.prefix} - Structure Components</module.name>
-        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <scm>


### PR DESCRIPTION
- the app / core / config modules use the reactor as parent; if they are not deployed, then pulling any of those in as a dependency requires the reactors to be present
- removing `<maven.deploy.skip>true</maven.deploy.skip>`, since not skipping is the default

