### PR TITLE
GH-149 adds authorVH attribute generation

### DIFF
--- a/apps/admin/core/pom.xml
+++ b/apps/admin/core/pom.xml
@@ -87,18 +87,27 @@ Bundle-DocURL:
         <!--testing-->
         <dependency>
             <groupId>com.adobe.dx</groupId>
-            <artifactId>testing</artifactId>
-            <version>0.0.10</version>
+            <artifactId>testing-extensions</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.adobe.dx</groupId>
             <artifactId>core</artifactId>
-            <version>0.0.12</version>
+            <version>0.0.13-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.jcr</groupId>
+            <artifactId>jcr</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>uber-jar</artifactId>
+            <version>${aem.version}</version>
             <classifier>apis</classifier>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/apps/admin/core/src/main/java/com/adobe/dx/admin/authorvh/AuthorVh.java
+++ b/apps/admin/core/src/main/java/com/adobe/dx/admin/authorvh/AuthorVh.java
@@ -1,0 +1,176 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.dx.admin.authorvh;
+
+import static com.day.cq.wcm.api.WCMMode.DISABLED;
+
+import com.adobe.dx.domtagging.AttributeWorker;
+import com.adobe.dx.responsive.Breakpoint;
+import com.adobe.dx.utils.RequestUtil;
+import com.day.cq.wcm.api.WCMMode;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+/**
+ * Fetches pattern of CSS vh usage, and outputs them as attributes
+ */
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE)
+@Designate(ocd = AuthorVh.Configuration.class)
+public class AuthorVh implements AttributeWorker {
+
+    private static final String CONFIG_SEPARATOR = ":";
+
+    public static final String KEY = "authorvh";
+
+    private static final String ATTRIBUTE_PREFIX = "data-author-vh-";
+
+    private static final String VH_SEPARATOR = ",";
+
+    private static final String ATTRIBUTE_PREFIX_ITEM = ATTRIBUTE_PREFIX + "item-";
+
+    Configuration configuration;
+
+    Map<String, String> typeMatch;
+
+    Map<String, String> valueProperty;
+
+    List<String> listParentNodeNames;
+
+    @Activate
+    @Modified
+    public void activate(Configuration configuration) {
+        this.configuration = configuration;
+        Map<String, String> types = new HashMap<>();
+        Map<String, String> values = new HashMap<>();
+        for (String pattern : configuration.propertyMatching()) {
+            String[] patterns = pattern.split(CONFIG_SEPARATOR);
+            if (patterns.length != 3) {
+                throw new IllegalArgumentException("there should be 3 parameters split by " + CONFIG_SEPARATOR);
+            }
+            types.put(patterns[0], patterns[1]);
+            values.put(patterns[0], patterns[2]);
+        }
+        typeMatch = types;
+        valueProperty = values;
+        listParentNodeNames = Arrays.asList(configuration.itemParents());
+    }
+
+    /**
+     * @param resource
+     * @param request
+     * @param breakpoint
+     * @return first match or null
+     */
+    private String extractVH(Resource resource, SlingHttpServletRequest request, Breakpoint breakpoint) {
+        for (Map.Entry<String, String> e : typeMatch.entrySet()) {
+            String typeValue = breakpoint != null ? RequestUtil.getFromRespProps(request, breakpoint, e.getKey())
+                : resource.getValueMap().get(e.getKey(), String.class);
+            if (StringUtils.isNotBlank(typeValue) && (typeValue.equals(e.getValue()))) {
+                String property = valueProperty.get(e.getKey());
+                Long value = breakpoint != null ? RequestUtil.getFromRespProps(request, breakpoint, property)
+                    : resource.getValueMap().get(property, Long.class);
+                if (value != null) {
+                    return value.toString();
+                }
+            }
+        }
+        return null;
+    }
+
+    private Map<String, String> addToMap(Map<String, String> existing, String key, String value) {
+        if (existing == null) {
+            existing = new HashMap<>();
+        }
+        existing.put(key, value);
+        return existing;
+    }
+
+    private String generateItemAttributes(Resource resource, SlingHttpServletRequest request) {
+        if (resource != null) {
+            return (String) IteratorUtils.toList(resource.listChildren()).stream()
+                .map(r -> extractVH((Resource) r, request, null))
+                .map(s -> s != null ? s : StringUtils.EMPTY)
+                .collect(Collectors.joining(VH_SEPARATOR));
+        }
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getAttributes(SlingHttpServletRequest request) {
+        if (DISABLED.equals(WCMMode.fromRequest(request))) {
+            return null;
+        }
+
+        Map<String, String> attributes = null;
+        for (Breakpoint breakpoint : RequestUtil.getBreakpoints(request)) {
+            if (breakpoint == null) {
+                continue;
+            }
+            String vh = extractVH(request.getResource(), request, breakpoint);
+            if (vh != null) {
+                attributes = addToMap(attributes, ATTRIBUTE_PREFIX + breakpoint.key(), vh);
+            }
+            for (String parent : listParentNodeNames) {
+                Resource parentResource = request.getResource().getChild(parent + breakpoint.propertySuffix());
+                String value = generateItemAttributes(parentResource, request);
+                if (value != null) {
+                    attributes = addToMap(attributes, ATTRIBUTE_PREFIX_ITEM + breakpoint.key(), value);
+                }
+            }
+        }
+        return attributes;
+    }
+
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    @ObjectClassDefinition(name = "Adobe Dx - Author VH Attribute worker")
+    public @interface Configuration {
+
+        @AttributeDefinition(
+            name = "Property Matching scheme",
+            description = "<typeProperty>:<typeValuePattern>:<valueProperty><br>"
+                + "<ul><li>type property is the property name we look for a type value match,</li>"
+                + "<li>typeValuePattern is a regexp we look at to check if current type property is a match.</li>"
+                + "<li>Value property is the property we look at in case of a match</li>"
+        )
+        String[] propertyMatching();
+
+        @AttributeDefinition(
+            name = "Items parent node names",
+            description = "itemParents"
+        )
+        String[] itemParents();
+    }
+}

--- a/apps/admin/core/src/test/java/com/adobe/dx/admin/authorvh/AuthorVhTest.java
+++ b/apps/admin/core/src/test/java/com/adobe/dx/admin/authorvh/AuthorVhTest.java
@@ -1,0 +1,81 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.dx.admin.authorvh;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.adobe.dx.testing.AbstractTest;
+import com.adobe.dx.testing.extensions.ResponsiveContext;
+import com.adobe.dx.testing.extensions.WCMModeDisabledContext;
+import com.adobe.dx.testing.extensions.WCMModeEditContext;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ResponsiveContext.class)
+class AuthorVhTest extends AbstractTest {
+
+    AuthorVh authorvh;
+
+    @BeforeEach
+    public void setup() {
+        authorvh = new AuthorVh();
+        context.registerInjectActivateService(authorvh,
+            "propertyMatching", new String[] { "minHeightType:vh:minHeightValue"},
+            "itemParents", new String[] { "definitions" });
+        context.build().resource(CONTENT_ROOT, "minHeightTypeTablet","vh","minHeightValueTablet", 51L, "sling:resourceType", "dx/some/component");
+        context.build().resource(CONTENT_ROOT +"/definitionsMobile")
+            .siblingsMode()
+            .resource("item0", "minHeight", "custom", "minHeightType", "vh", "minHeightValue", 12L, "width", "custom", "widthCustomValue", 200L, "widthCustomType", "px")
+            .resource("item1", "minHeight", "custom", "minHeightValue", 92L, "minHeightType", "px", "width", "auto")
+            .resource("item2", "minHeight", "auto", "minHeightType", "px", "width", "100%");
+        context.build().resource(CONTENT_ROOT +"/definitionsDesktop")
+            .siblingsMode()
+            .resource("item0", "minHeight", "auto", "minHeightType", "px", "width", "auto", "widthCustomType", "px", "order", 1L)
+            .resource("item1", "minHeight", "custom", "minHeightType", "vh","minHeightValue", 15L, "width", "33.33%", "widthCustomType", "px")
+            .resource("item2", "minHeight", "auto", "minHeightType", "px", "width", "33.33%", "widthCustomType", "px");
+        context.currentResource(CONTENT_ROOT);
+    }
+
+    @Test
+    public void lockKey() {
+        assertEquals("authorvh", authorvh.getKey());
+    }
+
+    @ExtendWith(WCMModeEditContext.class)
+    @Test
+    public void testGetAttributes() {
+        Map<String, String> attributes = authorvh.getAttributes(context.request());
+        assertNotNull(attributes);
+        assertArrayEquals(new String[]{"data-author-vh-tablet", "data-author-vh-item-mobile", "data-author-vh-item-desktop"},
+            attributes.keySet().toArray());
+        assertEquals("51", attributes.get("data-author-vh-tablet"));
+        assertEquals("12,,", attributes.get("data-author-vh-item-mobile"));
+        assertEquals(",15,", attributes.get("data-author-vh-item-desktop"));
+    }
+
+    @ExtendWith(WCMModeDisabledContext.class)
+    @Test
+    public void testGetAttributesOnPublish() {
+        assertNull(authorvh.getAttributes(context.request()));
+    }
+}

--- a/apps/admin/core/src/test/java/com/adobe/dx/admin/config/fonts/internal/TagImplTest.java
+++ b/apps/admin/core/src/test/java/com/adobe/dx/admin/config/fonts/internal/TagImplTest.java
@@ -26,11 +26,12 @@ import org.junit.jupiter.api.Test;
 class TagImplTest extends AbstractRequestModelTest {
     @BeforeEach
     private void setup() {
-        context.load().json("/mocks/admin.adobefonts/configuration-tree.json", CONF_ROOT);
-        context.load().json("/mocks/admin.adobefonts/content-tree.json", CONTENT_ROOT);
+        context.load().json("/mocks/admin.adobefonts/configuration-tree.json", CONF_ROOT + "/bar");
+        final String path = CONTENT_ROOT + "/bar";
+        context.load().json("/mocks/admin.adobefonts/content-tree.json", path);
         context.addModelsForPackage(TagImpl.class.getPackage().getName());
         context.registerInjectActivateService(new SettingsProviderImpl());
-        context.currentResource(CONTENT_ROOT + "/us/en");
+        context.currentResource(path + "/us/en");
     }
 
     @Test

--- a/apps/admin/core/src/test/java/com/adobe/dx/admin/config/manager/impl/ColumnViewDataSourceImplTest.java
+++ b/apps/admin/core/src/test/java/com/adobe/dx/admin/config/manager/impl/ColumnViewDataSourceImplTest.java
@@ -20,25 +20,26 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.adobe.dx.admin.config.manager.ColumnViewDataSource;
 import com.adobe.dx.admin.config.manager.ColumnViewItem;
 import com.adobe.dx.admin.config.manager.internal.ColumnViewDataSourceImpl;
-import com.adobe.dx.testing.AbstractRequestModelTest;
+import com.adobe.dx.testing.AbstractTest;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.sling.models.factory.ModelFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ColumnViewDataSourceImplTest extends AbstractRequestModelTest {
+class ColumnViewDataSourceImplTest extends AbstractTest {
     @BeforeEach
     private void setup() {
         context.load().json("/mocks/admin.configmanager/configuration-tree.json", CONF_ROOT);
         context.currentResource(CONF_ROOT);
-        context.addModelsForClasses(ColumnViewItem.class, ColumnViewDataSourceImpl.class);
+        context.addModelsForClasses(ColumnViewItem.class, ColumnViewDataSourceImpl.class, ColumnViewDataSource.class);
     }
 
     @Test
     public void testBrowsing() throws ReflectiveOperationException {
-        ColumnViewDataSource ds = getModel(ColumnViewDataSource.class);
+        ColumnViewDataSource ds = context.getService(ModelFactory.class).createModel(context.request(), ColumnViewDataSource.class);
         List<ColumnViewItem> firstChildren = ds.getItems();
         assertNotNull(firstChildren);
         assertEquals(1, firstChildren.size());

--- a/apps/admin/core/src/test/resources/OSGI-INF/com.adobe.dx.admin.authorvh.AuthorVh.xml
+++ b/apps/admin/core/src/test/resources/OSGI-INF/com.adobe.dx.admin.authorvh.AuthorVh.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" name="com.adobe.dx.admin.servlet.EncryptionServlet" configuration-policy="ignore">
+    <implementation class="com.adobe.dx.admin.authorvh.AuthorVh"/>
+    <service>
+        <provide interface="com.adobe.dx.domtagging.AttributeWorker"/>
+    </service>
+</scr:component>

--- a/apps/admin/core/src/test/resources/mocks/admin.adobefonts/content-tree.json
+++ b/apps/admin/core/src/test/resources/mocks/admin.adobefonts/content-tree.json
@@ -15,7 +15,7 @@
       "jcr:content": {
         "jcr:primaryType": "cq:PageContent",
         "jcr:title": "Some Random page",
-        "sling:configRef": "/conf/foo"
+        "sling:configRef": "/conf/foo/bar"
       }
     }
   }

--- a/apps/docs/app/jcr_root/apps/dx-docs/configs/config.author/com.adobe.dx.admin.authorvh.AuthorVh.config
+++ b/apps/docs/app/jcr_root/apps/dx-docs/configs/config.author/com.adobe.dx.admin.authorvh.AuthorVh.config
@@ -1,0 +1,2 @@
+propertyMatching=["minHeightType:vh:minHeightValue"]
+itemParents=["definitions"]

--- a/apps/docs/content/jcr_root/conf/dx-docs/_sling_configs/apps/dx/structure/components/flex/.content.xml
+++ b/apps/docs/content/jcr_root/conf/dx-docs/_sling_configs/apps/dx/structure/components/flex/.content.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="sling:Folder"
-        styleWorkers="[background,color,shadow,border,flex-general,flex-definitions]"/>
+styleWorkers="[background,color,shadow,border,flex-general,flex-definitions]"
+attributeWorkers="[authorvh]"/>

--- a/apps/docs/content/jcr_root/content/dx-docs/us/en/.content.xml
+++ b/apps/docs/content/jcr_root/content/dx-docs/us/en/.content.xml
@@ -21,6 +21,9 @@
                     shadowColor="red"
                     gapMobile="{Long}2"
                     focusXMobile="{Long}30"
+                    minHeightMobile="custom"
+                    minHeightTypeMobile="vh"
+                    minHeightValueMobile="{Long}60"
                     focusYMobile="{Long}30"
                     foregroundColorMobile="white"
                     gradientMobile="red"
@@ -57,7 +60,7 @@
                         <item1 jcr:primaryType="nt:unstructured"
                                minHeight="custom"
                                minHeightValue="60"
-                               minHeightType="%"
+                               minHeightType="vh"
                                width="custom"
                                customWidthValue="60"
                                customWidthType="%"/>

--- a/apps/structure/app/jcr_root/apps/dx/structure/components/flex/flex.html
+++ b/apps/structure/app/jcr_root/apps/dx/structure/components/flex/flex.html
@@ -18,6 +18,7 @@
 <div id="${model.id}" class="dx-flex">
     <div data-sly-element="${dxPolicy.elementName}"
          aria-label="${dxPolicy.ariaLabel}"
+         data-sly-attribute="${model.attributes}"
          role="${(!dxPolicy.elementName || dxPolicy.elementName == 'div') && dxPolicy.ariaLandmarkRole}"
          class="dx-flex-items"
          data-sly-resource="${'./items' @ resourceType='dx/structure/components/parlite'}"></div>

--- a/apps/structure/core/src/main/java/com/adobe/dx/structure/flex/FlexGeneralStyle.java
+++ b/apps/structure/core/src/main/java/com/adobe/dx/structure/flex/FlexGeneralStyle.java
@@ -19,6 +19,7 @@ import static com.adobe.dx.inlinestyle.Constants.DEL_SPACE;
 import static com.adobe.dx.inlinestyle.Constants.RULE_DELIMITER;
 import static com.adobe.dx.structure.flex.FlexModel.PN_MINHEIGHT;
 import static com.adobe.dx.structure.flex.FlexModel.PN_MINHEIGHT_TYPE;
+import static com.adobe.dx.structure.flex.FlexModel.PN_MINHEIGHT_VALUE;
 
 import com.adobe.dx.inlinestyle.InlineStyleWorker;
 import com.adobe.dx.responsive.Breakpoint;
@@ -59,7 +60,7 @@ public class FlexGeneralStyle implements InlineStyleWorker {
     }
 
     String computeMinHeight(Breakpoint breakpoint, SlingHttpServletRequest request) {
-        Long minHeight = RequestUtil.getFromRespProps(request, breakpoint, PN_MINHEIGHT);
+        Long minHeight = RequestUtil.getFromRespProps(request, breakpoint, PN_MINHEIGHT_VALUE);
         if ( minHeight != null) {
             String minHeightType = RequestUtil.getFromRespProps(request, breakpoint, PN_MINHEIGHT_TYPE);
             if (minHeightType != null) {

--- a/apps/structure/core/src/main/java/com/adobe/dx/structure/flex/FlexModel.java
+++ b/apps/structure/core/src/main/java/com/adobe/dx/structure/flex/FlexModel.java
@@ -15,8 +15,11 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.dx.structure.flex;
 
+import com.adobe.dx.domtagging.AttributeService;
 import com.adobe.dx.domtagging.IDTagger;
 import com.adobe.dx.inlinestyle.InlineStyleService;
+
+import java.util.Map;
 
 import javax.annotation.PostConstruct;
 
@@ -30,6 +33,7 @@ import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 public class FlexModel {
 
     public static final String PN_MINHEIGHT = "minHeight";
+    public static final String PN_MINHEIGHT_VALUE = PN_MINHEIGHT + "Value";
     public static final String PN_MINHEIGHT_TYPE = PN_MINHEIGHT + "Type";
 
     @SlingObject
@@ -41,9 +45,14 @@ public class FlexModel {
     @OSGiService
     InlineStyleService styleService;
 
+    @OSGiService
+    AttributeService attributeService;
+
     String id;
 
     String style;
+
+    Map<String, String> attributes;
 
     @PostConstruct
     void init() {
@@ -52,6 +61,9 @@ public class FlexModel {
         }
         if (styleService != null) {
             style = styleService.getInlineStyle(getId(), request);
+        }
+        if (attributeService != null) {
+            attributes = attributeService.getAttributes(request);
         }
     }
 
@@ -62,4 +74,6 @@ public class FlexModel {
     public String getStyle() {
         return style;
     }
+
+    public Map<String, String> getAttributes() { return attributes; }
 }

--- a/apps/structure/core/src/test/java/com/adobe/dx/structure/flex/FlexGeneralStyleTest.java
+++ b/apps/structure/core/src/test/java/com/adobe/dx/structure/flex/FlexGeneralStyleTest.java
@@ -11,7 +11,7 @@ class FlexGeneralStyleTest extends AbstractInlineStyleWorkerTest {
 
     @Test
     public void testRule() {
-        context.build().resource(CONTENT_ROOT, "minHeightMobile",
+        context.build().resource(CONTENT_ROOT, "minHeightValueMobile",
             20L, "minHeightTypeMobile", "px",
             "gapMobile", 30L);
         assertEquals("#this-is-my-flex > .dx-flex-items {\n"
@@ -24,7 +24,7 @@ class FlexGeneralStyleTest extends AbstractInlineStyleWorkerTest {
 
     @Test
     public void testRuleNoGap() {
-        context.build().resource(CONTENT_ROOT, "minHeightMobile",
+        context.build().resource(CONTENT_ROOT, "minHeightValueMobile",
             30L, "minHeightTypeMobile", "%");
         assertEquals("#this-is-my-flex > .dx-flex-items {\n"
             + "min-height: 30%\n"
@@ -33,7 +33,7 @@ class FlexGeneralStyleTest extends AbstractInlineStyleWorkerTest {
 
     @Test
     public void testNothing() {
-        context.build().resource(CONTENT_ROOT, "minHeightMobile",
+        context.build().resource(CONTENT_ROOT, "minHeightValueMobile",
             20L, "minHeightTypeMobile", "px",
             "gapMobile", 30L);
         assertNull(getRule("tablet", "this-is-my-flex"));

--- a/apps/structure/core/src/test/java/com/adobe/dx/structure/flex/FlexModelTest.java
+++ b/apps/structure/core/src/test/java/com/adobe/dx/structure/flex/FlexModelTest.java
@@ -17,9 +17,12 @@ package com.adobe.dx.structure.flex;
 
 import static org.junit.jupiter.api.Assertions.*;
 import com.adobe.dx.testing.AbstractRequestModelTest;
+import com.adobe.dx.testing.extensions.WCMModeDisabledContext;
+import com.adobe.dx.testing.extensions.WCMModeEditContext;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 class FlexModelTest extends AbstractRequestModelTest {
 
@@ -38,6 +41,12 @@ class FlexModelTest extends AbstractRequestModelTest {
     @Test
     public void testStyle() {
         assertNotNull(model.getStyle());
+    }
+
+    @ExtendWith(WCMModeDisabledContext.class)
+    @Test
+    public void testAuthorVH() {
+        assertNull(model.getAttributes());
     }
 
 }

--- a/bundles/core/src/main/java/com/adobe/dx/domtagging/AttributeService.java
+++ b/bundles/core/src/main/java/com/adobe/dx/domtagging/AttributeService.java
@@ -1,0 +1,36 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+package com.adobe.dx.domtagging;
+
+import java.util.Map;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Dynamically binds to the <code>AttributeWorker</code> instances in place, to provide contextual
+ * set of attributes for that component resource
+ */
+public interface AttributeService {
+
+    /**
+     * @param request current component request context
+     * @return map of attributes to be used for a given tag, corresponding to current request context
+     */
+    @Nullable Map<String, String> getAttributes(SlingHttpServletRequest request);
+
+}

--- a/bundles/core/src/main/java/com/adobe/dx/domtagging/AttributeWorker.java
+++ b/bundles/core/src/main/java/com/adobe/dx/domtagging/AttributeWorker.java
@@ -1,0 +1,31 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+package com.adobe.dx.domtagging;
+
+import com.adobe.dx.utils.Worker;
+
+import java.util.Map;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+
+public interface AttributeWorker extends Worker {
+
+    /**
+     * @return
+     */
+    Map<String, String> getAttributes(SlingHttpServletRequest request);
+}

--- a/bundles/core/src/main/java/com/adobe/dx/domtagging/internal/AttributeServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/dx/domtagging/internal/AttributeServiceImpl.java
@@ -1,0 +1,90 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+package com.adobe.dx.domtagging.internal;
+
+import com.adobe.dx.domtagging.AttributeService;
+import com.adobe.dx.domtagging.AttributeWorker;
+import com.adobe.dx.utils.AbstractWorkerManager;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.lucene.util.CollectionUtil;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE)
+public class AttributeServiceImpl extends AbstractWorkerManager<AttributeWorker> implements AttributeService {
+    Logger logger = LoggerFactory.getLogger(AttributeServiceImpl.class);
+
+    private static final String PN_ATTRIBUTEWORKERS = "attributeWorkers";
+
+    @Reference(service= AttributeWorker.class,
+        cardinality= ReferenceCardinality.MULTIPLE,
+        policy= ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY,
+        bind = "bindWorker", unbind = "unbindWorker")
+    final List<AttributeWorker> workers = new ArrayList<>();
+
+    @Override
+    public @Nullable Map<String, String> getAttributes(SlingHttpServletRequest request) {
+        Map<String, String> attributes = null;
+        for (String key : getWorkerKeys(request.getResource())) {
+            AttributeWorker worker = workersMap.get(key);
+            if (worker != null) {
+                logger.debug("found worker {}", worker.getKey());
+                Map<String, String> workerMap = worker.getAttributes(request);
+                if (attributes == null) {
+                    attributes = workerMap;
+                } else {
+                    attributes.putAll(workerMap);
+                }
+            }
+        }
+        return attributes;
+    }
+
+    @Override
+    protected List<AttributeWorker> getWorkers() {
+        return workers;
+    }
+
+    @Override
+    protected String getProperty() {
+        return PN_ATTRIBUTEWORKERS;
+    }
+
+    @Override
+    public void bindWorker(AttributeWorker worker) {
+        super.bindWorker(worker);
+    }
+
+    @Override
+    public void unbindWorker(AttributeWorker worker) {
+        super.unbindWorker(worker);
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/dx/domtagging/internal/AttributeServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/dx/domtagging/internal/AttributeServiceImpl.java
@@ -21,12 +21,9 @@ import com.adobe.dx.domtagging.AttributeWorker;
 import com.adobe.dx.utils.AbstractWorkerManager;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.lucene.util.CollectionUtil;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.service.component.annotations.Component;

--- a/bundles/core/src/main/java/com/adobe/dx/inlinestyle/InlineStyleWorker.java
+++ b/bundles/core/src/main/java/com/adobe/dx/inlinestyle/InlineStyleWorker.java
@@ -16,6 +16,7 @@
 package com.adobe.dx.inlinestyle;
 
 import com.adobe.dx.responsive.Breakpoint;
+import com.adobe.dx.utils.Worker;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.jetbrains.annotations.Nullable;
@@ -25,12 +26,7 @@ import org.jetbrains.annotations.Nullable;
  * for very specific usage in a style tag or attribute,
  * fed in the component context
  */
-public interface InlineStyleWorker {
-
-    /**
-     * @return key with which the worker can be identified
-     */
-    String getKey();
+public interface InlineStyleWorker extends Worker {
 
     /**
      * Generates a declaration specific to that generator

--- a/bundles/core/src/main/java/com/adobe/dx/utils/AbstractWorkerManager.java
+++ b/bundles/core/src/main/java/com/adobe/dx/utils/AbstractWorkerManager.java
@@ -1,0 +1,77 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+package com.adobe.dx.utils;
+
+import static com.day.cq.wcm.commons.Constants.EMPTY_STRING_ARRAY;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.caconfig.ConfigurationBuilder;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Get a list of workers depending on the resource type, and the bound workers
+ * @param <T>
+ */
+public abstract class AbstractWorkerManager <T extends Worker> {
+
+    protected abstract List<T> getWorkers();
+    protected abstract String getProperty();
+
+    private static final String SLASH = "/";
+    private static final String TYPE_PREFIX = "apps/";
+
+
+    protected Map<String, T> workersMap = MapUtils.EMPTY_MAP;
+
+    /**
+     * returns ordered list of workers for that given resource (or null)
+     */
+    protected @NotNull String[] getWorkerKeys(Resource resource) {
+        String type = resource.getResourceType();
+        String typePath = (type.startsWith(SLASH) ? type.substring(1) : TYPE_PREFIX + type);
+        ValueMap props = resource.adaptTo(ConfigurationBuilder.class).name(typePath).asValueMap();
+        String[] keys = props.get(getProperty(), String[].class);
+        if (keys != null) {
+            return keys;
+        }
+        return EMPTY_STRING_ARRAY;
+    }
+
+    protected void refreshWorkers() {
+        Map<String, T> map = new HashMap<>();
+        for (T worker : getWorkers()) {
+            map.put(worker.getKey(), worker);
+        }
+        workersMap = map;
+    }
+
+    protected void bindWorker(T worker) {
+        getWorkers().add(worker);
+        refreshWorkers();
+    }
+
+    protected void unbindWorker(T worker) {
+        getWorkers().remove(worker);
+        refreshWorkers();
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/dx/utils/Worker.java
+++ b/bundles/core/src/main/java/com/adobe/dx/utils/Worker.java
@@ -1,0 +1,25 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+package com.adobe.dx.utils;
+
+public interface Worker {
+
+    /**
+     * @return key with which the worker can be identified
+     */
+    String getKey();
+}

--- a/bundles/core/src/test/java/com/adobe/dx/domtagging/internal/AttributeServiceImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/dx/domtagging/internal/AttributeServiceImplTest.java
@@ -1,0 +1,105 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.dx.domtagging.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.adobe.dx.bindings.internal.DxBindingsValueProvider;
+import com.adobe.dx.domtagging.AttributeWorker;
+import com.adobe.dx.responsive.Breakpoint;
+import com.adobe.dx.responsive.internal.ResponsivePropertiesImpl;
+import com.adobe.dx.responsive.internal.ResponsivePropertiesImplTest;
+import com.adobe.dx.testing.AbstractTest;
+import com.adobe.dx.utils.RequestUtil;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AttributeServiceImplTest extends AbstractTest {
+    AttributeWorker worker1 = new AttributeWorker() {
+        @Override
+        public Map<String, String> getAttributes(SlingHttpServletRequest request) {
+            Map<String, String> map = new HashMap<>();
+            map.put("11", "11");
+            map.put("12", "12");
+            return map;
+        }
+
+        @Override
+        public String getKey() {
+            return "worker1";
+        }
+    };
+
+    AttributeWorker worker2 = new AttributeWorker() {
+        @Override
+        public Map<String, String> getAttributes(SlingHttpServletRequest request) {
+            Map<String, String> map = new HashMap<>();
+            map.put("21", "21");
+            map.put("22", "22");
+            return map;
+        }
+
+        @Override
+        public String getKey() {
+            return "worker2";
+        }
+    };
+
+    AttributeServiceImpl service;
+
+    @BeforeEach
+    void setup() {
+        List<Breakpoint> breakpoints = ResponsivePropertiesImplTest.initResponsiveConfiguration(context);
+        String someComp = CONTENT_ROOT + "/comp";
+        final String[] array = new String[] {"worker1", "worker2"};
+        context.build().resource(CONFIG_ROOTS  + "/apps/foo/bar",  "attributeWorkers", array);
+        context.build().resource(someComp, "sling:resourceType", "foo/bar");
+        context.currentResource(someComp);
+        ((SlingBindings)context.request().getAttribute(SlingBindings.class.getName())).put(DxBindingsValueProvider.POLICY_KEY, context.currentResource().getValueMap());
+        RequestUtil.getBindings(context.request()).put(DxBindingsValueProvider.BP_KEY,
+            breakpoints);
+        RequestUtil.getBindings(context.request()).put(DxBindingsValueProvider.RESP_PROPS_KEY,
+            new ResponsivePropertiesImpl(breakpoints, context.currentResource().getValueMap()));
+        service = new AttributeServiceImpl();
+    }
+
+    @Test
+    public void testNoWorker() {
+        assertNull(service.getAttributes(context.request()));
+    }
+
+    @Test
+    public void testOneWorker() {
+        service.bindWorker(worker1);
+        assertIterableEquals(Arrays.asList("11", "12"), service.getAttributes(context.request()).keySet());
+    }
+
+    @Test
+    public void testTwoWorker() {
+        service.bindWorker(worker1);
+        service.bindWorker(worker2);
+        assertTrue(CollectionUtils.isEqualCollection(Arrays.asList("11", "12", "21", "22"), service.getAttributes(context.request()).keySet()));
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/dx/inlinestyle/internal/InlineStyleServiceImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/dx/inlinestyle/internal/InlineStyleServiceImplTest.java
@@ -98,6 +98,7 @@ class InlineStyleServiceImplTest extends AbstractTest {
             return null;
         }
     };
+
     InlineStyleServiceImpl service;
 
     @BeforeEach
@@ -105,7 +106,7 @@ class InlineStyleServiceImplTest extends AbstractTest {
         List<Breakpoint> breakpoints = ResponsivePropertiesImplTest.initResponsiveConfiguration(context);
         String someComp = CONTENT_ROOT + "/comp";
         final String[] array = new String[] {"worker1", "worker2"};
-        context.build().resource(CONF_ROOT + "/sling:configs/apps/foo/bar",  "styleWorkers", array);
+        context.build().resource(CONFIG_ROOTS  + "/apps/foo/bar",  "styleWorkers", array);
         context.build().resource(someComp, "sling:resourceType", "foo/bar",
             "color", "blue",
             "minheightTablet", "200px",
@@ -157,21 +158,5 @@ class InlineStyleServiceImplTest extends AbstractTest {
         assertEquals("@media screen and (min-width: 600px) {\n"
             + "min-height: 200px\n"
             + "}", service.getInlineStyle(null, context.request()));
-    }
-
-    @Test
-    void getWorkerKeysFullPath() {
-        final String[] array = new String[] {"worker1", "worker2"};
-        context.build().resource("/apps/foo/bar", "styleWorkers", array);
-        context.build().resource(CONTENT_ROOT, "sling:resourceType", "foo/bar");
-        assertArrayEquals(array, new InlineStyleServiceImpl().getWorkerKeys(context.currentResource(CONTENT_ROOT)));
-    }
-
-
-    @Test
-    void getWorkerKeysNothing() {
-        context.build().resource("/apps/check/this", "blah", "blah");
-        context.build().resource(CONTENT_ROOT, "sling:resourceType", "check/this");
-        assertEquals(0, new InlineStyleServiceImpl().getWorkerKeys(context.currentResource(CONTENT_ROOT)).length);
     }
 }

--- a/bundles/core/src/test/java/com/adobe/dx/responsive/internal/ResponsivePropertiesImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/dx/responsive/internal/ResponsivePropertiesImplTest.java
@@ -46,6 +46,7 @@ public class ResponsivePropertiesImplTest extends AbstractTest {
     List<Breakpoint> breakpoints;
 
     public static List<Breakpoint> initResponsiveConfiguration(AemContext context) {
+        AbstractTest.initContentRoots(context);
         context.build().resource(CONF_ROOT + "/sling:configs/" + ResponsiveConfiguration.class.getName() + "/breakpoints")
             .siblingsMode()
             .resource("1","propertySuffix", "Mobile", "key", "mobile")
@@ -55,10 +56,6 @@ public class ResponsivePropertiesImplTest extends AbstractTest {
                 "inheritBehaviourProp", "inheritDesktop");
         MockContextAwareConfig.registerAnnotationClasses(context, ResponsiveConfiguration.class);
         MockContextAwareConfig.registerAnnotationClasses(context, Breakpoint.class);
-        if (context.resourceResolver().getResource(CONTENT_ROOT) == null) {
-            context.create().resource(CONTENT_ROOT);
-        }
-        context.build().resource(CONTENT_ROOT, "sling:configRef", CONF_ROOT);
         ResponsiveConfiguration configuration =  context.resourceResolver()
             .getResource(CONTENT_ROOT)
             .adaptTo(ConfigurationBuilder.class)

--- a/bundles/core/src/test/java/com/adobe/dx/utils/AbstractWorkerManagerTest.java
+++ b/bundles/core/src/test/java/com/adobe/dx/utils/AbstractWorkerManagerTest.java
@@ -1,0 +1,62 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.dx.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.adobe.dx.inlinestyle.internal.InlineStyleServiceImpl;
+import com.adobe.dx.responsive.Breakpoint;
+import com.adobe.dx.responsive.internal.ResponsivePropertiesImplTest;
+import com.adobe.dx.testing.AbstractTest;
+
+import java.util.List;
+
+import org.apache.sling.api.resource.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AbstractWorkerManagerTest extends AbstractTest {
+
+    final static String[] ARRAY = new String[] {"worker1", "worker2"};
+    final static String PATH = CONTENT_ROOT + "/comp";
+    Resource resource;
+
+    @BeforeEach
+    public void setup() {
+        AbstractTest.initContentRoots(context);
+        context.build().resource(CONFIG_ROOTS  + "/apps/foo/bar",  "styleWorkers", ARRAY);
+        context.build().resource(PATH, "sling:resourceType", "foo/bar");
+        resource = context.currentResource(PATH);
+    }
+
+    @Test
+    void getWorkerKeys() {
+        assertArrayEquals(ARRAY, new InlineStyleServiceImpl().getWorkerKeys(resource));
+    }
+
+    @Test
+    void getWorkerKeysFullPath() {
+        context.build().resource(CONTENT_ROOT, "sling:resourceType", "/apps/foo/bar");
+        assertArrayEquals(ARRAY, new InlineStyleServiceImpl().getWorkerKeys(resource));
+    }
+
+    @Test
+    void getWorkerKeysNothing() {
+        context.build().resource(CONTENT_ROOT, "sling:resourceType", "check/this");
+        resource = context.resourceResolver().getResource(CONTENT_ROOT);
+        assertEquals(0, new InlineStyleServiceImpl().getWorkerKeys(resource).length);
+    }
+}

--- a/bundles/testing-extensions/src/main/java/com/adobe/dx/testing/extensions/ExtensionsUtil.java
+++ b/bundles/testing-extensions/src/main/java/com/adobe/dx/testing/extensions/ExtensionsUtil.java
@@ -29,7 +29,6 @@ public class ExtensionsUtil {
     private static final String CONTEXT_FIELD = "context";
 
     private ExtensionsUtil() {
-
     }
 
     private static void putAllFields(Map<String, Field> fields, Class<?> type) {

--- a/bundles/testing-extensions/src/main/java/com/adobe/dx/testing/extensions/ResponsiveContext.java
+++ b/bundles/testing-extensions/src/main/java/com/adobe/dx/testing/extensions/ResponsiveContext.java
@@ -43,7 +43,7 @@ public class ResponsiveContext implements BeforeEachCallback {
     @Override
     public void beforeEach(ExtensionContext extensionContext) throws Exception {
         AemContext context = getContext(extensionContext);
-        context.build().resource(CONF_ROOT + "/sling:configs/" + ResponsiveConfiguration.class.getName() + "/breakpoints")
+        context.build().resource(AbstractTest.CONFIG_ROOTS + "/" + ResponsiveConfiguration.class.getName() + "/breakpoints")
             .siblingsMode()
             .resource("1", PROPERTY_SUFFIX, "Mobile", "key", "mobile")
             .resource("2", PROPERTY_SUFFIX, "Tablet",
@@ -56,10 +56,7 @@ public class ResponsiveContext implements BeforeEachCallback {
                 "inheritBehaviourProp", "inheritDesktop");
         MockContextAwareConfig.registerAnnotationClasses(context, ResponsiveConfiguration.class);
         MockContextAwareConfig.registerAnnotationClasses(context, Breakpoint.class);
-        if (context.resourceResolver().getResource(CONTENT_ROOT) == null) {
-            context.create().resource(CONTENT_ROOT);
-        }
-        context.build().resource(CONTENT_ROOT, "sling:configRef", CONF_ROOT);
+        AbstractTest.initContentRoots(context);
         Resource resource = context.resourceResolver().getResource(CONTENT_ROOT);
         if (resource != null) {
             ConfigurationBuilder builder = resource.adaptTo(ConfigurationBuilder.class);

--- a/bundles/testing-extensions/src/main/java/com/adobe/dx/testing/extensions/StyleGuideContext.java
+++ b/bundles/testing-extensions/src/main/java/com/adobe/dx/testing/extensions/StyleGuideContext.java
@@ -15,6 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.dx.testing.extensions;
 
+import static com.adobe.dx.testing.AbstractTest.CONFIG_ROOTS;
 import static com.adobe.dx.testing.AbstractTest.CONF_ROOT;
 
 import com.adobe.dx.styleguide.StyleGuide;
@@ -33,7 +34,7 @@ public class StyleGuideContext implements BeforeEachCallback {
     
     @Override
     public void beforeEach(ExtensionContext extensionContext) throws Exception {
-        String confRoot = CONF_ROOT + "/sling:configs/" + StyleGuide.class.getName() + "/";
+        String confRoot = CONFIG_ROOTS + "/" + StyleGuide.class.getName() + "/";
         AemContext context = ExtensionsUtil.getContext(extensionContext);
         context.build().resource(confRoot + "colors")
             .siblingsMode()

--- a/bundles/testing-extensions/src/main/java/com/adobe/dx/testing/extensions/WCMModeDisabledContext.java
+++ b/bundles/testing-extensions/src/main/java/com/adobe/dx/testing/extensions/WCMModeDisabledContext.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ *
+ * ADOBE CONFIDENTIAL
+ * __________________
+ *
+ *  Copyright 2019 Adobe
+ *  All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains
+ * the property of Adobe and its suppliers, if any. The intellectual
+ * and technical concepts contained herein are proprietary to Adobe
+ * and its suppliers and are protected by all applicable intellectual
+ * property laws, including trade secret and copyright laws.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe.
+ ******************************************************************************/
+
+package com.adobe.dx.testing.extensions;
+
+import static com.adobe.dx.testing.extensions.ExtensionsUtil.getContext;
+import static com.day.cq.wcm.api.WCMMode.REQUEST_ATTRIBUTE_NAME;
+
+import com.day.cq.wcm.api.WCMMode;
+
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+
+public class WCMModeDisabledContext implements BeforeTestExecutionCallback {
+    @Override
+    public void beforeTestExecution(ExtensionContext extensionContext) throws Exception {
+        AemContext context = getContext(extensionContext);
+        context.request().setAttribute(REQUEST_ATTRIBUTE_NAME, WCMMode.DISABLED);
+    }
+}

--- a/bundles/testing-extensions/src/main/java/com/adobe/dx/testing/extensions/WCMModeEditContext.java
+++ b/bundles/testing-extensions/src/main/java/com/adobe/dx/testing/extensions/WCMModeEditContext.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ *
+ * ADOBE CONFIDENTIAL
+ * __________________
+ *
+ *  Copyright 2019 Adobe
+ *  All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains
+ * the property of Adobe and its suppliers, if any. The intellectual
+ * and technical concepts contained herein are proprietary to Adobe
+ * and its suppliers and are protected by all applicable intellectual
+ * property laws, including trade secret and copyright laws.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe.
+ ******************************************************************************/
+
+package com.adobe.dx.testing.extensions;
+
+import static com.adobe.dx.testing.extensions.ExtensionsUtil.getContext;
+import static com.day.cq.wcm.api.WCMMode.REQUEST_ATTRIBUTE_NAME;
+
+import com.day.cq.wcm.api.WCMMode;
+
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+
+public class WCMModeEditContext implements BeforeTestExecutionCallback {
+    @Override
+    public void beforeTestExecution(ExtensionContext extensionContext) throws Exception {
+        AemContext context = getContext(extensionContext);
+        context.request().setAttribute(REQUEST_ATTRIBUTE_NAME, WCMMode.EDIT);
+    }
+}

--- a/bundles/testing-extensions/src/main/resources/OSGI-INF/com.adobe.dx.inlinestyle.internal.InlineStyleServiceImpl.xml
+++ b/bundles/testing-extensions/src/main/resources/OSGI-INF/com.adobe.dx.inlinestyle.internal.InlineStyleServiceImpl.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" name="com.adobe.dx.utils.service.internal.CloudConfigReaderImpl" configuration-policy="ignore">
-    <implementation class="com.adobe.dx.inlinestyle.internal.inlinestyle"/>
+    <implementation class="com.adobe.dx.inlinestyle.internal.InlineStyleServiceImpl"/>
     <service>
         <provide interface="com.adobe.dx.inlinestyle.InlineStyleService"/>
     </service>
-    <reference name="resourceResolverFactory"
-               interface="org.apache.sling.api.resource.ResourceResolverFactory" field="resourceResolverFactory"/>
+    <reference name="workers"
+               interface="com.adobe.dx.inlinestyle.InlineStyleWorker" field="workers" cardinality="0..n"
+               bind="bindWorkers"
+               unbind="unbindWorkers"/>
 </scr:component>

--- a/bundles/testing-extensions/src/test/java/com/adobe/dx/testing/SomeModelTest.java
+++ b/bundles/testing-extensions/src/test/java/com/adobe/dx/testing/SomeModelTest.java
@@ -16,9 +16,15 @@
 
 package com.adobe.dx.testing;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.adobe.dx.testing.extensions.WCMModeDisabledContext;
+import com.adobe.dx.testing.extensions.WCMModeEditContext;
+import com.day.cq.wcm.api.WCMMode;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 public class SomeModelTest extends AbstractRequestModelTest {
 
@@ -27,5 +33,17 @@ public class SomeModelTest extends AbstractRequestModelTest {
         context.build().resource(CONTENT_ROOT, "foo", "bar");
         SomeModel model = getModel(SomeModel.class, CONTENT_ROOT);
         assertNotNull(model.getId());
+    }
+
+    @ExtendWith(WCMModeDisabledContext.class)
+    @Test
+    public void testWCMModeDisabled() {
+        assertEquals(WCMMode.DISABLED, WCMMode.fromRequest(context.request()));
+    }
+
+    @ExtendWith(WCMModeEditContext.class)
+    @Test
+    public void testWCMModeEdit() {
+        assertEquals(WCMMode.EDIT, WCMMode.fromRequest(context.request()));
     }
 }

--- a/bundles/testing/src/main/java/com/adobe/dx/testing/AbstractTest.java
+++ b/bundles/testing/src/main/java/com/adobe/dx/testing/AbstractTest.java
@@ -31,6 +31,7 @@ public class AbstractTest {
 
     public static final String CONTENT_ROOT = "/content/foo";
     public static final String CONF_ROOT = "/conf/foo";
+    public static final String CONFIG_ROOTS = CONF_ROOT + "/sling:configs";
 
     public AemContext context = buildContext(getType());
 
@@ -42,6 +43,16 @@ public class AbstractTest {
         return new AemContextBuilder(type)
             .plugin(CACONFIG)
             .build();
+    }
+
+    public static void initContentRoots(AemContext context) {
+        if (context.resourceResolver().getResource(CONFIG_ROOTS) == null) {
+            context.create().resource(CONF_ROOT + "/sling:configs");
+        }
+        if (context.resourceResolver().getResource(CONTENT_ROOT) == null) {
+            context.create().resource(CONTENT_ROOT);
+        }
+        context.build().resource(CONTENT_ROOT, "sling:configRef", CONF_ROOT);
     }
 
     public static ValueMap getVM(AemContext context, String path) {

--- a/bundles/testing/src/test/java/com/adobe/dx/testing/AbstractTestTest.java
+++ b/bundles/testing/src/test/java/com/adobe/dx/testing/AbstractTestTest.java
@@ -15,8 +15,12 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.dx.testing;
 
+import static com.adobe.dx.testing.AbstractTest.CONF_ROOT;
+import static com.adobe.dx.testing.AbstractTest.CONTENT_ROOT;
 import static com.adobe.dx.testing.AbstractTest.buildContext;
+import static com.adobe.dx.testing.AbstractTest.getVM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
@@ -45,5 +49,15 @@ class AbstractTestTest {
         ValueMap properties = test.getVM(AbstractTest.CONTENT_ROOT);
         assertEquals("bar", properties.get("foo"));
         assertEquals(2, properties.get("blah"));
+    }
+
+    @Test
+    public void initContentRoot() {
+        AbstractTest.initContentRoots(context);
+        //call twice to ensure it does not fail
+        AbstractTest.initContentRoots(context);
+        assertNotNull(getVM(context, CONF_ROOT));
+        assertNotNull(getVM(context, CONTENT_ROOT));
+        assertEquals(CONF_ROOT, getVM(context, CONTENT_ROOT).get("sling:configRef"));
     }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -43,6 +43,7 @@
 
     <developers>
         <developer>
+            <id>mwpw</id>
             <name>Adobe Web Platform team</name>
             <email>grp-dexter-tech@adobe.com</email>
         </developer>


### PR DESCRIPTION
- generalize the concept of workers with AbstractWorkerManager,
- adds as extensions of it InlineStyleService and AttributeManager (that works with AttributeWorker),
- adds an AttributeWorker, AuthorVh, in admin application (so it's not active at all on author),
- makes AuthorVh as generic as possible, but for now focused on working with flex,
- create 2 new test extensions WCMModeDisabledContext and WCMModeEditContext for usage in AuthorVhTest
<img width="1067" alt="Screenshot 2020-09-19 at 00 42 03" src="https://user-images.githubusercontent.com/1032754/93651456-ce415e80-fa11-11ea-9a21-818a28d65f1c.png">
