### PR TITLE
Add sourcemaps for npm run watch

### DIFF
--- a/apps/admin/app/webpack.config.js
+++ b/apps/admin/app/webpack.config.js
@@ -29,7 +29,6 @@ const {
 } = require(`${monoRoot}webpack-scripts/miniCssExtractWrapper.js`);
 const optimization = require(`${monoRoot}webpack-scripts/optimization.js`);
 const optimizeCssAssets = require(`${monoRoot}webpack-scripts/optimizeCssAssetsWrapper.js`);
-const devtool = require(`${monoRoot}webpack-scripts/devtool.js`);
 const performance = require(`${monoRoot}webpack-scripts/performance.js`);
 const stats = require(`${monoRoot}webpack-scripts/stats.js`);
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -46,8 +45,6 @@ const rules = [eslintLoader, babelLoader, miniCssExtractLoader()];
 if (!isProduction) {
     rules.push(prettierLoader);
 }
-
-console.log(devtool());
 
 module.exports = {
     entry: {
@@ -72,7 +69,8 @@ module.exports = {
         react: 'React',
         'react-dom': 'ReactDOM',
     },
-    optimization,
+    optimization: isProduction ? optimization : { minimize: false },
+    devtool: 'inline-source-map',
     plugins: [
         new webpack.DefinePlugin(spectrumConfig),
         new MiniCssExtractPlugin({ filename: '[name]/dist/css/app.min.css' }),


### PR DESCRIPTION
Source maps were not working when working on author libraries.

## Description

The eval-* source maps are recommended, but no matter what config was tried I would get
`ReferenceError: __webpack_require__ is not defined`

However the non eval `inline-source-map` does work.  It is claimed that this is the slowest compiling of all the source maps, but in my testing the times are maybe 1 second slower.  This may be due to the small size of the codebase but for now seems acceptable vs not having source maps at all when developing.

