### PR TITLE
Adds another search criteria to the find function of the replace pipe

### DIFF
--- a/apps/scripts/app/jcr_root/apps/dx/scripts/libs/replace/.content.xml
+++ b/apps/scripts/app/jcr_root/apps/dx/scripts/libs/replace/.content.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:primaryType="sling:Folder"
-    jcr:description="pls use that pipe as a reference, specifying in bindings a 'property' and 'oldValue' you want to replace, plus 'newValue'"
-    sling:resourceType="slingPipes/container"/>
+          jcr:title="Replace Property value"
+          jcr:primaryType="sling:Folder"
+          jcr:description="This pipe can be used to change a property of a resource. The search consists of two properties to search for.
+    curl -u admin:admin http://localhost:4502/apps/dx/scripts/libs/replace.json
+    -X POST -v -F bindings=&quot;{
+      'root':'/content/{path}',
+      'type':'cq:PageContent',
+      'property':'sling:resourceType',
+      'criteria':'cq:template',
+      'criteriavalue':'/conf/myproject/settings/wcm/templates/mytemplate',
+      'oldValue':'myApp/components/structure/page',
+      'newValue':'myApp/components/structure/newPage'}&quot;"
+          sling:resourceType="slingPipes/container"/>

--- a/apps/scripts/app/jcr_root/apps/dx/scripts/libs/replace/.content.xml
+++ b/apps/scripts/app/jcr_root/apps/dx/scripts/libs/replace/.content.xml
@@ -7,9 +7,7 @@
     -X POST -v -F bindings=&quot;{
       'root':'/content/{path}',
       'type':'cq:PageContent',
+      'criteria':'@cq:template=&quot;/conf/myproject/settings/wcm/templates/mytemplate&quot; and @sling:resourceType=&quot;myApp/components/structure/page&quot;',
       'property':'sling:resourceType',
-      'criteria':'cq:template',
-      'criteriavalue':'/conf/myproject/settings/wcm/templates/mytemplate',
-      'oldValue':'myApp/components/structure/page',
       'newValue':'myApp/components/structure/newPage'}&quot;"
           sling:resourceType="slingPipes/container"/>

--- a/apps/scripts/app/jcr_root/apps/dx/scripts/libs/replace/conf/find/.content.xml
+++ b/apps/scripts/app/jcr_root/apps/dx/scripts/libs/replace/conf/find/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="sling:OrderedFolder"
-          jcr:description="searches for all nodes with property '${property}' equals to '${oldvalue}' and property '${criteria}' eqals to '${criteriavalue}' within ${root}"
+          jcr:description="searches for all nodes with element type '${type}' and a '${criteria}' within ${root}"
           sling:resourceType="slingPipes/xpath"
           expr='/jcr:root${root}//element(*,${type})[${criteria}]'/>

--- a/apps/scripts/app/jcr_root/apps/dx/scripts/libs/replace/conf/find/.content.xml
+++ b/apps/scripts/app/jcr_root/apps/dx/scripts/libs/replace/conf/find/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:primaryType="sling:OrderedFolder"
-    jcr:description="searches for all nodes with property '${property}' equals to '${oldvalue}' within ${root}"
-    sling:resourceType="slingPipes/xpath"
-    expr='/jcr:root${root}//element(*,${type})[@${property}="${oldValue}"]'/>
+          jcr:primaryType="sling:OrderedFolder"
+          jcr:description="searches for all nodes with property '${property}' equals to '${oldvalue}' and property '${criteria}' eqals to '${criteriavalue}' within ${root}"
+          sling:resourceType="slingPipes/xpath"
+          expr='/jcr:root${root}//element(*,${type})[@${property}="${oldValue}" and @${criteria}="${criteriavalue}"]'/>

--- a/apps/scripts/app/jcr_root/apps/dx/scripts/libs/replace/conf/find/.content.xml
+++ b/apps/scripts/app/jcr_root/apps/dx/scripts/libs/replace/conf/find/.content.xml
@@ -3,4 +3,4 @@
           jcr:primaryType="sling:OrderedFolder"
           jcr:description="searches for all nodes with property '${property}' equals to '${oldvalue}' and property '${criteria}' eqals to '${criteriavalue}' within ${root}"
           sling:resourceType="slingPipes/xpath"
-          expr='/jcr:root${root}//element(*,${type})[@${property}="${oldValue}" and @${criteria}="${criteriavalue}"]'/>
+          expr='/jcr:root${root}//element(*,${type})[${criteria}]'/>


### PR DESCRIPTION
## Description

The current replace function allows to find resources with a specific property and replace the property value. This PR extends the functionality, that another criteria is added to the find xpath function, which allows to search for two properties (e.g. a resourceType and a template in combination)

## Motivation and Context

The current replace function does not allow to have more constraints. In most of the projects such a scenario is seldom. It's more often, that two properties/constraints are needed to find specific resources. The motivation is, that this change leads to a more reusable pipe.

## How Has This Been Tested?

The code was built and deployed to a local AEM 6.5.7 instance (only scripts package). The pipe has been run via curl command: 

`curl -u admin:admin http://localhost:4502/apps/dx/scripts/libs/replace.json -X POST -v -F bindings="{'root':'/content/experience-fragments','type':'cq:PageContent','property':'sling:resourceType','oldValue':'project/components/structure/xfpage','newValue':'project2/components/structure/xfpage', 'criteria':'cq:template', 'criteriavalue':'/conf/project/settings/wcm/templates/experience-fragment'}" -F dryRun=true`


## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

