### PR TITLE
allowing the pipe shell script to accept arguments with spaces

### DIFF
--- a/apps/scripts/pipe
+++ b/apps/scripts/pipe
@@ -27,8 +27,9 @@ function do_curl() {
 }
 
 #function to generate transform arg1=val1,arg2=val2 into {"arg1":"val1","arg2":"val2"}
+#the function also accepts values with spaces. These statements must then be surrounded with single quotes. e.g. arg1='value with space'
 function generate_json() {
-  echo {\"`echo "$1"| sed s/=/\":\"/g| sed s/\,/\"\,\"/g`\"}
+  echo "$1" | sed 's/\(.*\)/\1,/' | sed -r 's/([^=,]*)\=['\'']?([^,'\'']*)['\'']?[,]/"\1":"\2",/g' | sed 's/.$//' | sed 's/\(.*\)/\{\1\}/'
 }
 
 function show_help() {
@@ -83,7 +84,7 @@ while [ $# -gt 0 ]; do
                 s)  server=$2; shift ;;
                 u)  user=$2; shift ;;
                 d)  opts="-F dryRun=true $opts";;
-		            b)  opts="-F bindings='`generate_json "$2"`' $opts"; shift ;;
+                b)  opts="-F bindings='`generate_json "$2"`' $opts"; shift ;;
                 c)  uri=/apps/dx/scripts/exec.csv ;;
                 n)  opts="-F size=$2 $opts"; shift ;;
                 o)  opts="-F writer=$2 $opts"; shift ;;


### PR DESCRIPTION
## Description
This PR contains a change in the pipe shell script, which allows to have argument values with spaces and other statements. 

## Motivation and Context

The change is motivated due to the recent change of the replace pipe, which accepts a lot more freedom. But the change would only allow running the pipe with direct curl call or other triggers. 

The PR allows to call the following command:

`./pipe -s http://localhost:4502 -b "root=/content/experience-fragments,type=cq:PageContent,criteria='@cq:template="/conf/myApp/settings/wcm/templates/experience-fragment-template" and @sling:resourceType="oldApp/components/structure/xfpage"',property=sling:resourceType,newValue=newApp/components/structure/xfpage"`

## How Has This Been Tested?

This has currently been tested with a debug option in the pipe shell script. It also has been tested altering the pipe script to use -F instead of -d option. see GH-195

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

