### PR TITLE
GH-195: using form param instead of data

### DIFF
--- a/apps/scripts/pipe
+++ b/apps/scripts/pipe
@@ -101,6 +101,6 @@ if [ -f "$cmd" ]; then
   opts="-F pipe_cmdfile=@$cmd $opts"
   do_curl
 else
-	opts="-d pipe_cmd=\"$cmd\" $opts"
+	opts="-F pipe_cmd=\"$cmd\" $opts"
 	do_curl
 fi


### PR DESCRIPTION
This PR changes the pipe client script to use multipart form data and replaces the current -d data option

<!--- Provide a general summary of your changes in the Title above -->

## Description
The change is necessary because in curl it's not possible to mix the data (-d) option with multipart form (-f)
The script is changed at only one place.

<!--- Describe your changes in detail -->

## Related Issue

see issue Description GH-195

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

it has been tested by executing some example pipe commands locally.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

