### PR TITLE
refactor pipe script and improve debug mode

### DIFF
--- a/apps/scripts/pipe
+++ b/apps/scripts/pipe
@@ -19,11 +19,16 @@
 
 #main function that ends up being called by this client
 function do_curl() {
-  curlCommand="curl -u $user -s $verbose -S $opts $server$uri"
   if [ "$pipe_debug" ]; then
-    echo "$curlCommand"
+    set -x
   fi
-  eval "$curlCommand"
+  curl \
+    --user $user \
+    --show-error --silent \
+    $verbose \
+    --form "$cmd" \
+    $opts \
+    $server$uri
 }
 
 #function to generate transform arg1=val1,arg2=val2 into {"arg1":"val1","arg2":"val2"}
@@ -66,8 +71,8 @@ if [ -z "$uri" ]; then
 	uri=/apps/dx/scripts/exec.$ext
 fi
 if [ -z "$verbose" ]; then
-	verbose=" --fail "
-	pipe_debug=1
+	verbose="--fail"
+  pipe_debug=true
 fi
 
 while [ $# -gt 0 ]; do
@@ -89,13 +94,13 @@ while [ $# -gt 0 ]; do
                 h)  show_help; exit ;;
                 s)  server=$2; shift ;;
                 u)  user=$2; shift ;;
-		v)  verbose=' -v '; shift ;;
-                d)  opts="-F dryRun=true $opts";;
-                b)  opts="-F bindings='`generate_json "$2"`' $opts"; shift ;;
+		            v)  verbose="--verbose"; shift ;;
+                d)  opts="--form dryRun=true $opts";;
+                b)  opts="--form bindings='$(generate_json "$2")' $opts"; shift ;;
                 c)  uri=/apps/dx/scripts/exec.csv ;;
-                n)  opts="-F size=$2 $opts"; shift ;;
-		f)  opts="-F pipes_inputFile=@$2"; shift ;;
-                o)  opts="-F writer=$2 $opts"; shift ;;
+                n)  opts="--form size=$2 $opts"; shift ;;
+		            f)  opts="--form pipes_inputFile=@$2"; shift ;;
+                o)  opts="--form writer=$2 $opts"; shift ;;
                 *)  userfail "Unrecognized option." ;;
             esac
         done
@@ -107,9 +112,9 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -f "$cmd" ]; then
-  opts="-F pipe_cmdfile=@$cmd $opts"
-  do_curl
+  cmd="pipe_cmdfile=@$cmd"
 else
-	opts="-F pipe_cmd=\"$cmd\" $opts"
-	do_curl
+	cmd="pipe_cmd=$cmd"
 fi
+
+do_curl

--- a/apps/scripts/pipe
+++ b/apps/scripts/pipe
@@ -71,7 +71,7 @@ if [ -z "$uri" ]; then
 	uri=/apps/dx/scripts/exec.$ext
 fi
 if [ -z "$verbose" ]; then
-	verbose="--fail"
+  verbose="--fail"
   pipe_debug=true
 fi
 
@@ -94,12 +94,12 @@ while [ $# -gt 0 ]; do
                 h)  show_help; exit ;;
                 s)  server=$2; shift ;;
                 u)  user=$2; shift ;;
-		            v)  verbose="--verbose"; shift ;;
+                v)  verbose="--verbose"; shift ;;
                 d)  opts="--form dryRun=true $opts";;
                 b)  opts="--form bindings='$(generate_json "$2")' $opts"; shift ;;
                 c)  uri=/apps/dx/scripts/exec.csv ;;
                 n)  opts="--form size=$2 $opts"; shift ;;
-		            f)  opts="--form pipes_inputFile=@$2"; shift ;;
+                f)  opts="--form pipes_inputFile=@$2"; shift ;;
                 o)  opts="--form writer=$2 $opts"; shift ;;
                 *)  userfail "Unrecognized option." ;;
             esac
@@ -114,7 +114,7 @@ done
 if [ -f "$cmd" ]; then
   cmd="pipe_cmdfile=@$cmd"
 else
-	cmd="pipe_cmd=$cmd"
+  cmd="pipe_cmd=$cmd"
 fi
 
 do_curl


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- switch to long options to make [command more readable](https://superuser.com/questions/174564/why-are-there-short-and-long-alternatives-for-command-line-options/174638#174638)
- improve debug mode by using `set -x`, which does show how command arguments are split;
`echo` outputs values without quotes, which makes it difficult to debug arguments split by incorrectly escaped whitespaces 
- fix indents

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

