### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - id: log
-      run: echo "::set-output name=message::$(git log --no-merges -1 --oneline)"
+      run: echo "message=$(git log --no-merges -1 --oneline)" >> $GITHUB_OUTPUT
     - if: "contains(steps.log.outputs.message, '@releng')"
       run: echo "exiting...this is a CI commit" && exit 1
     - uses: actions/setup-java@v1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter